### PR TITLE
[Style] 로그인, 임시 비밀번호 발급, 비밀번호 변경 페이지 스타일 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4223,7 +4223,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -4498,7 +4497,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
@@ -6777,7 +6775,6 @@
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
             "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7086,7 +7083,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -7133,7 +7129,6 @@
             "version": "8.4.49",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
             "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -7179,7 +7174,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
             "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "camelcase-css": "^2.0.1"
@@ -8151,7 +8145,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"

--- a/src/components/forgot-password/Success.tsx
+++ b/src/components/forgot-password/Success.tsx
@@ -12,7 +12,7 @@ export default function Success() {
 
     return (
         <>
-            <section className="bg-white flex-1 flex flex-col justify-center items-center">
+            <section className="flex-1 flex flex-col justify-center items-center">
                 <Check className="mb-2" />
                 <h2 className="text-gray-800 text-title-s font-extrabold">
                     전송 완료
@@ -24,10 +24,7 @@ export default function Success() {
                 <Dog />
             </section>
             <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto">
-                <button
-                    onClick={handleCheckBtn}
-                    className="w-full text-body-l font-extrabold text-white py-3 mb-8 rounded-lg bg-point-500 active:bg-point-600 hover:bg-point-600"
-                >
+                <button onClick={handleCheckBtn} className="btn-solid mb-8">
                     확인
                 </button>
             </footer>

--- a/src/hooks/useChangePasswordForm.ts
+++ b/src/hooks/useChangePasswordForm.ts
@@ -42,50 +42,53 @@ export default function useChangePasswordForm() {
     /**
      * current Password validation
      */
-    const currentPasswordValidation = register('currentPassword', {
-        required: '현재 비밀번호는 필수입니다',
+    const currentPasswordValidation = {
+        required: '현재 비밀번호는 필수입니다!',
         minLength: {
             value: 8,
-            message: '비밀번호는 최소 8자 이상이어야 합니다',
+            message: '비밀번호는 최소 8자 이상이어야 합니다!',
         },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,
-            message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다',
+            message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다!',
         },
-    });
+    };
 
     /**
      * new Password validation
      */
-    const newPasswordValidation = register('newPassword', {
-        required: '새 비밀번호는 필수입니다',
+    const newPasswordValidation = {
+        required: '새 비밀번호는 필수입니다!',
         minLength: {
             value: 8,
-            message: '비밀번호는 최소 8자 이상이어야 합니다',
+            message: '비밀번호는 최소 8자 이상이어야 합니다!',
         },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,
-            message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다',
+            message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다!',
         },
-        validate: (value) =>
+        validate: (value: string) =>
             value !== watch('currentPassword') ||
-            '새 비밀번호는 현재 비밀번호와 다르게 설정해야 합니다',
-    });
+            '새 비밀번호는 현재 비밀번호와 다르게 설정해야 합니다!',
+    };
 
     /**
      * confirm Password validation
      */
-    const confirmPasswordValidation = register('confirmPassword', {
-        required: '비밀번호 확인은 필수입니다',
-        validate: (value) =>
-            value === watch('newPassword') || '새 비밀번호와 일치하지 않습니다',
-    });
+    const confirmPasswordValidation = {
+        required: '비밀번호 확인은 필수입니다!',
+        validate: (value: string) =>
+            value === watch('newPassword') ||
+            '새 비밀번호와 일치하지 않습니다!',
+    };
 
     return {
         currentPasswordValidation,
         newPasswordValidation,
         confirmPasswordValidation,
+        register,
         handleSubmit,
+        watch,
         errors,
         onSubmit,
         isValid,

--- a/src/hooks/useForgotPasswordForm.ts
+++ b/src/hooks/useForgotPasswordForm.ts
@@ -17,6 +17,7 @@ export default function useForgotPasswordForm() {
     const {
         register,
         handleSubmit,
+        watch,
         formState: { errors, isValid },
     } = useForm<ForgotPasswordInputs>({
         mode: 'onChange',
@@ -35,17 +36,19 @@ export default function useForgotPasswordForm() {
     /**
      * Email validation
      */
-    const emailValidation = register('email', {
-        required: '이메일은 필수입니다',
+    const emailValidation = {
+        required: '이메일은 필수입니다!',
         pattern: {
             value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-            message: '유효한 이메일 주소를 입력해주세요',
+            message: '유효한 이메일 주소를 입력해주세요!',
         },
-    });
+    };
 
     return {
         emailValidation,
+        register,
         handleSubmit,
+        watch,
         errors,
         onSubmit,
         isValid,

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -20,6 +20,7 @@ export default function useLoginForm() {
     const {
         register,
         handleSubmit,
+        watch,
         formState: { errors, isValid },
     } = useForm<LoginInputs>({
         mode: 'onChange',
@@ -42,33 +43,35 @@ export default function useLoginForm() {
     /**
      * Email validation
      */
-    const emailValidation = register('email', {
-        required: '이메일은 필수입니다',
+    const emailValidation = {
+        required: '이메일은 필수입니다!',
         pattern: {
             value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-            message: '유효한 이메일 주소를 입력해주세요',
+            message: '유효한 이메일 주소를 입력해주세요!',
         },
-    });
+    };
 
     /**
      * Password validation
      */
-    const passwordValidation = register('password', {
-        required: '비밀번호는 필수입니다',
+    const passwordValidation = {
+        required: '비밀번호는 필수입니다!',
         minLength: {
             value: 8,
-            message: '비밀번호는 최소 8자 이상이어야 합니다',
+            message: '비밀번호는 최소 8자 이상이어야 합니다!',
         },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,
-            message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다',
+            message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다!',
         },
-    });
+    };
 
     return {
         emailValidation,
         passwordValidation,
+        register,
         handleSubmit,
+        watch,
         errors,
         onSubmit,
         isValid,

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -33,53 +33,55 @@ export default function ChangePassword() {
                 </h1>
             </header>
             <section className="flex-1 flex flex-col justify-start">
-                <div className="bg-white px-6 pt-6 pb-12 flex flex-col">
-                    <div className="text-title-s font-extrabold text-gray-800 pb-12">
-                        <p>새로운 비밀번호를</p>
-                        <p>입력해주세요!</p>
+                <div className="bg-white pt-6 pb-12 flex flex-col">
+                    <div className="w-full max-w-[600px] px-6 mx-auto">
+                        <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                            <p>새로운 비밀번호를</p>
+                            <p>입력해주세요!</p>
+                        </div>
+                        <form
+                            id="change-form"
+                            onSubmit={handleSubmit(onSubmit)}
+                            className="flex flex-col gap-1"
+                        >
+                            <CustomInput
+                                id="currentPassword"
+                                label="현재 비밀번호"
+                                type="text"
+                                placeholder="현재 비밀번호를 입력해주세요."
+                                register={register}
+                                watch={watch}
+                                validation={currentPasswordValidation}
+                                error={errors.currentPassword?.message}
+                                design="outline"
+                                successMsg="좋아요!"
+                            />
+                            <CustomInput
+                                id="newPassword"
+                                label="새로운 비밀번호"
+                                type="password"
+                                placeholder="새로운 비밀번호를 입력해주세요."
+                                register={register}
+                                watch={watch}
+                                validation={newPasswordValidation}
+                                error={errors.newPassword?.message}
+                                design="outline"
+                                successMsg="좋아요!"
+                            />
+                            <CustomInput
+                                id="confirmPassword"
+                                label="새로운 비밀번호 확인"
+                                type="password"
+                                placeholder="새로운 비밀번호를 한번 더 입력해주세요."
+                                register={register}
+                                watch={watch}
+                                validation={confirmPasswordValidation}
+                                error={errors.confirmPassword?.message}
+                                design="outline"
+                                successMsg="좋아요!"
+                            />
+                        </form>
                     </div>
-                    <form
-                        id="change-form"
-                        onSubmit={handleSubmit(onSubmit)}
-                        className="flex flex-col gap-1"
-                    >
-                        <CustomInput
-                            id="currentPassword"
-                            label="현재 비밀번호"
-                            type="text"
-                            placeholder="현재 비밀번호를 입력해주세요."
-                            register={register}
-                            watch={watch}
-                            validation={currentPasswordValidation}
-                            error={errors.currentPassword?.message}
-                            design="outline"
-                            successMsg="좋아요!"
-                        />
-                        <CustomInput
-                            id="newPassword"
-                            label="새로운 비밀번호"
-                            type="password"
-                            placeholder="새로운 비밀번호를 입력해주세요."
-                            register={register}
-                            watch={watch}
-                            validation={newPasswordValidation}
-                            error={errors.newPassword?.message}
-                            design="outline"
-                            successMsg="좋아요!"
-                        />
-                        <CustomInput
-                            id="confirmPassword"
-                            label="새로운 비밀번호 확인"
-                            type="password"
-                            placeholder="새로운 비밀번호를 한번 더 입력해주세요."
-                            register={register}
-                            watch={watch}
-                            validation={confirmPasswordValidation}
-                            error={errors.confirmPassword?.message}
-                            design="outline"
-                            successMsg="좋아요!"
-                        />
-                    </form>
                 </div>
             </section>
             <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto flex flex-col gap-[10px]">

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -1,10 +1,9 @@
-import { useChangePasswordForm } from '@/hooks';
+import { useChangePasswordForm, useFadeNavigate } from '@/hooks';
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Back from '@/assets/images/header/back.svg?react';
 
 export default function ChangePassword() {
-    const navigate = useNavigate();
+    const navigate = useFadeNavigate();
     const {
         currentPasswordValidation,
         newPasswordValidation,
@@ -93,16 +92,13 @@ export default function ChangePassword() {
                 </div>
             </section>
             <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto flex flex-col gap-[10px]">
-                <button
-                    onClick={handleBackBtn}
-                    className="w-full text-body-l font-extrabold text-point-600 py-3 rounded-lg bg-white active:bg-point-200 hover:bg-point-200 border-2 border-point-600"
-                >
+                <button onClick={handleBackBtn} className="btn-outline">
                     돌아가기
                 </button>
                 <button
                     type="submit"
                     form="change-form"
-                    className="w-full text-body-l font-extrabold text-white py-3 mb-8 rounded-lg bg-point-500 active:bg-point-600 hover:bg-point-600 disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+                    className="btn-solid mb-8"
                     disabled={
                         !isValid ||
                         !!errors.currentPassword ||

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -1,6 +1,7 @@
 import { useChangePasswordForm, useFadeNavigate } from '@/hooks';
 import { useCallback } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
+import { CustomInput } from '@/components/common';
 
 export default function ChangePassword() {
     const navigate = useFadeNavigate();
@@ -8,7 +9,9 @@ export default function ChangePassword() {
         currentPasswordValidation,
         newPasswordValidation,
         confirmPasswordValidation,
+        register,
         handleSubmit,
+        watch,
         errors,
         onSubmit,
         isValid,
@@ -38,56 +41,44 @@ export default function ChangePassword() {
                     <form
                         id="change-form"
                         onSubmit={handleSubmit(onSubmit)}
-                        className="flex flex-col"
+                        className="flex flex-col gap-1"
                     >
-                        <label
-                            htmlFor="currentPassword"
-                            className="text-label-m text-gray-500 pb-2"
-                        >
-                            현재 비밀번호
-                        </label>
-                        <input
+                        <CustomInput
                             id="currentPassword"
+                            label="현재 비밀번호"
                             type="text"
-                            placeholder="현재 비밀번호"
-                            {...currentPasswordValidation}
-                            className="mb-[22px]"
+                            placeholder="현재 비밀번호를 입력해주세요."
+                            register={register}
+                            watch={watch}
+                            validation={currentPasswordValidation}
+                            error={errors.currentPassword?.message}
+                            design="outline"
+                            successMsg="좋아요!"
                         />
-                        <label
-                            htmlFor="currentPassword"
-                            className="text-label-m text-gray-500 pb-2"
-                        >
-                            새로운 비밀번호
-                        </label>
-                        <input
+                        <CustomInput
                             id="newPassword"
+                            label="새로운 비밀번호"
                             type="password"
-                            placeholder="새 비밀번호"
-                            {...newPasswordValidation}
-                            className="mb-[22px]"
+                            placeholder="새로운 비밀번호를 입력해주세요."
+                            register={register}
+                            watch={watch}
+                            validation={newPasswordValidation}
+                            error={errors.newPassword?.message}
+                            design="outline"
+                            successMsg="좋아요!"
                         />
-                        <label
-                            htmlFor="currentPassword"
-                            className="text-label-m text-gray-500 pb-2"
-                        >
-                            새로운 비밀번호 확인
-                        </label>
-                        <input
+                        <CustomInput
                             id="confirmPassword"
+                            label="새로운 비밀번호 확인"
                             type="password"
-                            placeholder="새 비밀번호 재입력"
-                            {...confirmPasswordValidation}
-                            className="mb-[22px]"
+                            placeholder="새로운 비밀번호를 한번 더 입력해주세요."
+                            register={register}
+                            watch={watch}
+                            validation={confirmPasswordValidation}
+                            error={errors.confirmPassword?.message}
+                            design="outline"
+                            successMsg="좋아요!"
                         />
-                        {errors.currentPassword ? (
-                            <span>{errors.currentPassword.message}</span>
-                        ) : errors.newPassword ? (
-                            <span>{errors.newPassword.message}</span>
-                        ) : (
-                            errors.confirmPassword && (
-                                <span>{errors.confirmPassword.message}</span>
-                            )
-                        )}
                     </form>
                 </div>
             </section>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -2,12 +2,15 @@ import { useFadeNavigate, useForgotPasswordForm } from '@/hooks';
 import { useCallback } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
 import Success from '@/components/forgot-password/Success';
+import { CustomInput } from '@/components/common';
 
 export default function ForgotPassword() {
     const navigate = useFadeNavigate();
     const {
         emailValidation,
+        register,
         handleSubmit,
+        watch,
         errors,
         onSubmit,
         isValid,
@@ -42,24 +45,19 @@ export default function ForgotPassword() {
                             <form
                                 id="forgot-form"
                                 onSubmit={handleSubmit(onSubmit)}
-                                className="flex flex-col"
                             >
-                                <label
-                                    htmlFor="email"
-                                    className="text-label-m text-gray-500 pb-2"
-                                >
-                                    이메일
-                                </label>
-                                <input
+                                <CustomInput
                                     id="email"
+                                    label="이메일"
                                     type="text"
                                     placeholder="이메일을 입력해주세요."
-                                    {...emailValidation}
-                                    className="mb-[22px]"
+                                    register={register}
+                                    watch={watch}
+                                    validation={emailValidation}
+                                    error={errors.email?.message}
+                                    design="outline"
+                                    successMsg="좋아요!"
                                 />
-                                {errors.email && (
-                                    <span>{errors.email.message}</span>
-                                )}
                             </form>
                         </div>
                     </section>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -65,7 +65,7 @@ export default function ForgotPassword() {
                         <button
                             type="submit"
                             form="forgot-form"
-                            className="w-full text-body-l font-extrabold text-white py-3 mb-8 rounded-lg bg-point-500 active:bg-point-600 hover:bg-point-600 disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+                            className="btn-solid mb-8"
                             disabled={!isValid || !!errors.email}
                         >
                             확인

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -19,7 +19,9 @@ export default function ForgotPassword() {
     }, []);
 
     return (
-        <div className="h-screen bg-gray-100 flex flex-col justify-between overflow-hidden">
+        <div
+            className={`h-screen ${success ? 'bg-white' : 'bg-gray-100'} flex flex-col justify-between overflow-hidden`}
+        >
             <header className="bg-white sm:h-24 h-14 w-full flex items-center justify-center">
                 <Back
                     onClick={handleBackBtn}

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -37,28 +37,30 @@ export default function ForgotPassword() {
             {!success ? (
                 <>
                     <section className="flex-1 flex flex-col justify-start">
-                        <div className="bg-white px-6 pt-6 pb-12 flex flex-col">
-                            <div className="text-title-s font-extrabold text-gray-800 pb-12">
-                                <p>임시 비밀번호를</p>
-                                <p>이메일로 보내드릴게요!</p>
+                        <div className="bg-white pt-6 pb-12 flex flex-col">
+                            <div className="w-full max-w-[600px] px-6 mx-auto">
+                                <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                                    <p>임시 비밀번호를</p>
+                                    <p>이메일로 보내드릴게요!</p>
+                                </div>
+                                <form
+                                    id="forgot-form"
+                                    onSubmit={handleSubmit(onSubmit)}
+                                >
+                                    <CustomInput
+                                        id="email"
+                                        label="이메일"
+                                        type="text"
+                                        placeholder="이메일을 입력해주세요."
+                                        register={register}
+                                        watch={watch}
+                                        validation={emailValidation}
+                                        error={errors.email?.message}
+                                        design="outline"
+                                        successMsg="좋아요!"
+                                    />
+                                </form>
                             </div>
-                            <form
-                                id="forgot-form"
-                                onSubmit={handleSubmit(onSubmit)}
-                            >
-                                <CustomInput
-                                    id="email"
-                                    label="이메일"
-                                    type="text"
-                                    placeholder="이메일을 입력해주세요."
-                                    register={register}
-                                    watch={watch}
-                                    validation={emailValidation}
-                                    error={errors.email?.message}
-                                    design="outline"
-                                    successMsg="좋아요!"
-                                />
-                            </form>
                         </div>
                     </section>
                     <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,12 +3,15 @@ import Back from '@/assets/images/header/back.svg?react';
 import Forward from '@/assets/images/login/forward.svg?react';
 import { useCallback } from 'react';
 import { Success } from '@/components/login';
+import { CustomInput } from '@/components/common';
 
 export default function Login() {
     const {
         emailValidation,
         passwordValidation,
+        register,
         handleSubmit,
+        watch,
         errors,
         onSubmit,
         isValid,
@@ -54,39 +57,32 @@ export default function Login() {
                         onSubmit={handleSubmit(onSubmit)}
                         className="flex flex-col"
                     >
-                        <label
-                            htmlFor="email"
-                            className="text-label-m text-gray-500 pb-2"
-                        >
-                            이메일
-                        </label>
-                        <input
-                            id="email"
-                            type="text"
-                            placeholder="이메일을 입력해주세요."
-                            {...emailValidation}
-                            className="mb-[22px]"
-                        />
-                        <label
-                            htmlFor="password"
-                            className="text-label-m text-gray-500 pb-2"
-                        >
-                            비밀번호
-                        </label>
-                        <input
-                            id="password"
-                            type="password"
-                            placeholder="비밀번호를 입력해주세요."
-                            {...passwordValidation}
-                            className="mb-[22px]"
-                        />
-                        {errors.email ? (
-                            <span>{errors.email.message}</span>
-                        ) : (
-                            errors.password && (
-                                <span>{errors.password.message}</span>
-                            )
-                        )}
+                        <div className="flex flex-col gap-1">
+                            <CustomInput
+                                id="email"
+                                label="이메일"
+                                type="text"
+                                placeholder="이메일을 입력해주세요."
+                                register={register}
+                                watch={watch}
+                                validation={emailValidation}
+                                error={errors.email?.message}
+                                design="outline"
+                                successMsg="좋아요!"
+                            />
+                            <CustomInput
+                                id="password"
+                                label="비밀번호"
+                                type="password"
+                                placeholder="비밀번호를 입력해주세요."
+                                register={register}
+                                watch={watch}
+                                validation={passwordValidation}
+                                error={errors.password?.message}
+                                design="outline"
+                                successMsg="좋아요!"
+                            />
+                        </div>
                         <div className="flex justify-end items-center w-full">
                             <span
                                 onClick={handleForgotPWBtn}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -47,51 +47,53 @@ export default function Login() {
                 </h1>
             </header>
             <section className="flex-1 flex flex-col justify-start">
-                <div className="bg-white px-6 pt-6 pb-12 flex flex-col">
-                    <div className="text-title-s font-extrabold text-gray-800 pb-12">
-                        <p>이메일로</p>
-                        <p>로그인을 해주세요.</p>
+                <div className="bg-white pt-6 pb-12 flex flex-col">
+                    <div className="w-full max-w-[600px] px-6 mx-auto">
+                        <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                            <p>이메일로</p>
+                            <p>로그인을 해주세요.</p>
+                        </div>
+                        <form
+                            id="login-form"
+                            onSubmit={handleSubmit(onSubmit)}
+                            className="flex flex-col"
+                        >
+                            <div className="flex flex-col gap-1">
+                                <CustomInput
+                                    id="email"
+                                    label="이메일"
+                                    type="text"
+                                    placeholder="이메일을 입력해주세요."
+                                    register={register}
+                                    watch={watch}
+                                    validation={emailValidation}
+                                    error={errors.email?.message}
+                                    design="outline"
+                                    successMsg="좋아요!"
+                                />
+                                <CustomInput
+                                    id="password"
+                                    label="비밀번호"
+                                    type="password"
+                                    placeholder="비밀번호를 입력해주세요."
+                                    register={register}
+                                    watch={watch}
+                                    validation={passwordValidation}
+                                    error={errors.password?.message}
+                                    design="outline"
+                                    successMsg="좋아요!"
+                                />
+                            </div>
+                            <div className="flex justify-end items-center w-full">
+                                <span
+                                    onClick={handleForgotPWBtn}
+                                    className="text-label-l font-semibold text-point-400 cursor-pointer"
+                                >
+                                    비밀번호를 잊으셨나요?
+                                </span>
+                            </div>
+                        </form>
                     </div>
-                    <form
-                        id="login-form"
-                        onSubmit={handleSubmit(onSubmit)}
-                        className="flex flex-col"
-                    >
-                        <div className="flex flex-col gap-1">
-                            <CustomInput
-                                id="email"
-                                label="이메일"
-                                type="text"
-                                placeholder="이메일을 입력해주세요."
-                                register={register}
-                                watch={watch}
-                                validation={emailValidation}
-                                error={errors.email?.message}
-                                design="outline"
-                                successMsg="좋아요!"
-                            />
-                            <CustomInput
-                                id="password"
-                                label="비밀번호"
-                                type="password"
-                                placeholder="비밀번호를 입력해주세요."
-                                register={register}
-                                watch={watch}
-                                validation={passwordValidation}
-                                error={errors.password?.message}
-                                design="outline"
-                                successMsg="좋아요!"
-                            />
-                        </div>
-                        <div className="flex justify-end items-center w-full">
-                            <span
-                                onClick={handleForgotPWBtn}
-                                className="text-label-l font-semibold text-point-400 cursor-pointer"
-                            >
-                                비밀번호를 잊으셨나요?
-                            </span>
-                        </div>
-                    </form>
                 </div>
             </section>
             <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -109,7 +109,7 @@ export default function Login() {
                 <button
                     type="submit"
                     form="login-form"
-                    className="w-full text-body-l font-extrabold text-white py-3 mb-8 rounded-lg bg-point-500 active:bg-point-600 hover:bg-point-600 disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+                    className="btn-solid mb-8"
                     disabled={!isValid || !!errors.email || !!errors.password}
                 >
                     로그인


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

로그인과 비밀번호 설정 관련 페이지에서의 button 스타일 변경 및 커스텀 input 컴포넌트 적용

## 📌 이슈 넘버

- #38 

## 📝 작업 내용

- 로그인 페이지 버튼 tailwind CSS 변경
- 임시 비밀번호 발급 페이지 버튼 tailwind CSS 변경
- 임시 비밀번호 발급 완료 페이지 버튼 tailwind CSS 변경
- 비밀번호 변경 페이지 버튼 tailwind CSS 변경
- 로그인 페이지에 커스텀 input 컴포넌트 적용
- 임시 비밀번호 발급 페이지에 커스텀 input 컴포넌트 적용
- 비밀번호 변경 페이지에 커스텀 input 컴포넌트 적용

## 📸 스크린샷(선택)

<img width="253" alt="화면 캡처 2024-11-24 185808" src="https://github.com/user-attachments/assets/2d667ce8-760f-435a-99ab-68af6af74ccb">
<img width="254" alt="화면 캡처 2024-11-24 185835" src="https://github.com/user-attachments/assets/9eba9b97-64a6-4c7a-b5f2-af16fa3f17e3">
<img width="258" alt="화면 캡처 2024-11-24 185910" src="https://github.com/user-attachments/assets/5b5dfe35-b039-4b9b-945d-738efd4ec7ff">
<img width="253" alt="화면 캡처 2024-11-24 185942" src="https://github.com/user-attachments/assets/fc5b8beb-a664-43d7-808e-b9de3e5fd925">
<img width="257" alt="화면 캡처 2024-11-24 190018" src="https://github.com/user-attachments/assets/0e0e774e-914a-4bd1-9779-ce90774bc07a">
<img width="256" alt="화면 캡처 2024-11-24 190048" src="https://github.com/user-attachments/assets/c824dd85-0d43-4cda-ace5-c635699c5fa3">

## 리뷰 요구사항(선택)

- 커스텀 input 컴포넌트에 입력시 자동 완성 기능을 사용하게 되면 파랗게 되는 예외 발견
