### PR TITLE
[Feat] 회원가입 페이지 3,4 단계 컴포넌트 작성

### DIFF
--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -46,17 +46,31 @@ export default function CustomInput<T extends FieldValues>({
                 {label}
             </label>
             <div className="flex flex-col gap-[4px]">
-                <input
-                    className={inputClasses.trim()}
-                    id={id}
-                    type={type}
-                    placeholder={placeholder}
-                    {...register(id, validation)}
-                    style={{
-                        WebkitBoxShadow: '0 0 0 30px white inset',
-                        WebkitTextFillColor: 'inherit',
-                    }}
-                />
+                {type !== 'textarea' ? (
+                    <input
+                        className={inputClasses.trim()}
+                        id={id}
+                        type={type}
+                        placeholder={placeholder}
+                        {...register(id, validation)}
+                        style={{
+                            WebkitBoxShadow: '0 0 0 30px white inset',
+                            WebkitTextFillColor: 'inherit',
+                        }}
+                    />
+                ) : (
+                    <textarea
+                        className="w-full py-[12px] px-[24px] border-1 border-gray-200 focus:outline-none rounded-lg text-body-m text-gray-900 placeholder:text-gray-400 focus:caret-point-500 disabled:placeholder:text-gray-200 disabled:placeholder:bg-gray-200 h-32 resize-none bg-white"
+                        rows={3}
+                        id={id}
+                        placeholder={placeholder}
+                        {...register(id, validation)}
+                        style={{
+                            WebkitBoxShadow: '0 0 0 30px white inset',
+                            WebkitTextFillColor: 'inherit',
+                        }}
+                    />
+                )}
                 <p className="text-label-s px-[24px]">
                     {error ? (
                         <span className="text-warning-400 flex items-center gap-[0.5px]">

--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -60,7 +60,7 @@ export default function CustomInput<T extends FieldValues>({
                     />
                 ) : (
                     <textarea
-                        className="w-full py-[12px] px-[24px] border-1 border-gray-200 focus:outline-none rounded-lg text-body-m text-gray-900 placeholder:text-gray-400 focus:caret-point-500 disabled:placeholder:text-gray-200 disabled:placeholder:bg-gray-200 h-32 resize-none bg-white"
+                        className={`${error ? 'input-warning' : successMsg && inputValue ? 'input-success' : 'border-gray-200'} w-full py-[12px] px-[24px] border-1 focus:outline-none rounded-lg text-body-m text-gray-900 placeholder:text-gray-400 focus:caret-point-500 disabled:placeholder:text-gray-200 disabled:placeholder:bg-gray-200 h-32 resize-none bg-white`}
                         rows={3}
                         id={id}
                         placeholder={placeholder}

--- a/src/components/common/ImageSelectBox.tsx
+++ b/src/components/common/ImageSelectBox.tsx
@@ -73,7 +73,7 @@ export default function ImageSelectBox({
                             />
                         </div>
                     </section>
-                    <section className="flex gap-[10px]">
+                    <section className="flex gap-[10px] w-full max-w-[600px] mx-auto">
                         <button
                             onClick={handleToggleBottomSheetBtn}
                             className="btn-outline flex-1"
@@ -94,7 +94,7 @@ export default function ImageSelectBox({
 
     return (
         <div className={`w-full mx-auto flex flex-col gap-2 ${className}`}>
-            <label className="text-label-m">{label}</label>
+            <label className="text-label-m text-gray-500">{label}</label>
             <div className="w-full flex justify-center pb-[18px]">
                 <div className="relative">
                     <img

--- a/src/components/signup/FirstStep.tsx
+++ b/src/components/signup/FirstStep.tsx
@@ -118,7 +118,6 @@ export default function FirstStep({
                 className={`w-full max-w-[600px] px-6 py-2.5 mx-auto ${pageNumber !== 1 && 'hidden'}`}
             >
                 <button
-                    form="none"
                     className="btn-solid mb-8"
                     disabled={
                         !sentNumber || !!errors.email || !verificationCode

--- a/src/components/signup/FirstStep.tsx
+++ b/src/components/signup/FirstStep.tsx
@@ -4,12 +4,7 @@ import {
     verificationCodeValidationType,
 } from '@/hooks/useSignupForm';
 import { CustomInput } from '../common';
-import {
-    FieldErrors,
-    UseFormRegister,
-    UseFormTrigger,
-    UseFormWatch,
-} from 'react-hook-form';
+import { FieldErrors, UseFormRegister, UseFormWatch } from 'react-hook-form';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface FirstStepPropsType {
@@ -19,7 +14,6 @@ interface FirstStepPropsType {
     emailValidation: emailValidationType;
     verificationCodeValidation: verificationCodeValidationType;
     errors: FieldErrors<SignUpInputs>;
-    trigger: UseFormTrigger<SignUpInputs>;
     isValid: boolean;
     setPageNumber: React.Dispatch<React.SetStateAction<number>>;
 }
@@ -31,7 +25,6 @@ export default function FirstStep({
     emailValidation,
     verificationCodeValidation,
     errors,
-    trigger,
     isValid,
     setPageNumber,
 }: FirstStepPropsType) {
@@ -43,17 +36,10 @@ export default function FirstStep({
     const verificationCode = watch('verificationCode');
 
     useEffect(() => {
-        if (email) {
-            trigger('email');
-        }
-        if (verificationCode) {
-            trigger('verificationCode');
-        }
         emailTyped.current = true;
-    }, [email, verificationCode, trigger]);
+    });
 
     const handleVerificateEmailBtn = useCallback(() => {
-        console.log(email);
         setFirstVisit(false);
         // api 요청
         setSentNumber(true);
@@ -63,7 +49,7 @@ export default function FirstStep({
         // api 요청
         console.log('1번 페이지 성공');
         setSentNumber(false);
-        setPageNumber(2);
+        setPageNumber((prev) => prev + 1);
     }, []);
 
     return (
@@ -96,6 +82,7 @@ export default function FirstStep({
                                     />
                                 </div>
                                 <button
+                                    form="none"
                                     className="btn-solid btn-md"
                                     disabled={
                                         (!emailTyped.current && !isValid) ||
@@ -131,8 +118,7 @@ export default function FirstStep({
                 className={`w-full max-w-[600px] px-6 py-2.5 mx-auto ${pageNumber !== 1 && 'hidden'}`}
             >
                 <button
-                    type="submit"
-                    form="signup-form"
+                    form="none"
                     className="btn-solid mb-8"
                     disabled={
                         !sentNumber || !!errors.email || !verificationCode

--- a/src/components/signup/FourthStep.tsx
+++ b/src/components/signup/FourthStep.tsx
@@ -1,0 +1,156 @@
+import { SignUpInputs } from '@/hooks/useSignupForm';
+import {
+    Control,
+    Controller,
+    FieldErrors,
+    UseFormRegister,
+    UseFormWatch,
+} from 'react-hook-form';
+import { CustomToggle, MultiSelectTag, SelectBox } from '../common';
+import { useSelectBox } from '@/hooks';
+import { Option } from '@/hooks/useSelectBox';
+
+interface FourthStepPropsType {
+    pageNumber: number;
+    register: UseFormRegister<SignUpInputs>;
+    watch: UseFormWatch<SignUpInputs>;
+    errors: FieldErrors<SignUpInputs>;
+    control: Control<SignUpInputs, any>;
+}
+
+export default function FourthStep({
+    pageNumber,
+    register,
+    watch,
+    errors,
+    control,
+}: FourthStepPropsType) {
+    // 강아지 크기 옵션 정의
+    const dogSizeOptions = [
+        { value: 'small', label: '소형견' },
+        { value: 'medium', label: '중형견' },
+        { value: 'large', label: '대형견' },
+    ];
+
+    const options: Option[] = [
+        { value: 'ENFP', label: 'ENFP' },
+        { value: 'ENFJ', label: 'ENFJ' },
+        { value: 'ENTP', label: 'ENTP' },
+        { value: 'ENTJ', label: 'ENTJ' },
+        { value: 'ESFP', label: 'ESFP' },
+        { value: 'ESFJ', label: 'ESFJ' },
+        { value: 'ESTP', label: 'ESTP' },
+        { value: 'ESTJ', label: 'ESTJ' },
+        { value: 'INFP', label: 'INFP' },
+        { value: 'INFJ', label: 'INFJ' },
+        { value: 'INTP', label: 'INTP' },
+        { value: 'INTJ', label: 'INTJ' },
+        { value: 'ISFP', label: 'ISFP' },
+        { value: 'ISFJ', label: 'ISFJ' },
+        { value: 'ISTP', label: 'ISTP' },
+        { value: 'ISTJ', label: 'ISTJ' },
+    ];
+
+    const {
+        options: selectOptions,
+        selectOption,
+        isOpen,
+        toggleSelectBox,
+        selectedOption,
+        selectBoxRef,
+    } = useSelectBox(options);
+
+    return (
+        <>
+            <div className={`${pageNumber !== 4 && 'hidden'}`}>
+                {/* 프로그래스바 */}
+                <div className="w-full bg-white h-1">
+                    <div className="bg-point-400 h-1 w-[100%]"></div>
+                </div>
+                <div className="bg-white pt-6 pb-12">
+                    <div className="w-full max-w-[600px] px-6 mx-auto">
+                        <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                            <p>마지막으로</p>
+                            <p>추가 정보가 필요해요!</p>
+                        </div>
+                        {pageNumber === 4 && (
+                            <div className="flex flex-col gap-1">
+                                <div className="flex flex-col gap-7">
+                                    <CustomToggle
+                                        name="gender"
+                                        label="성별"
+                                        leftText="여성"
+                                        rightText="남성"
+                                        register={register}
+                                        watch={watch}
+                                        defaultChecked={true}
+                                    />
+                                    <CustomToggle
+                                        name="possible"
+                                        label="돌봄이 가능 여부"
+                                        leftText="가능"
+                                        rightText="불가능"
+                                        register={register}
+                                        watch={watch}
+                                        defaultChecked={true}
+                                    />
+                                    <MultiSelectTag
+                                        label="선호 애견 크기"
+                                        name="dogSizes"
+                                        options={dogSizeOptions}
+                                        control={control}
+                                        rules={{
+                                            required:
+                                                '최소 하나의 크기를 선택해주세요!',
+                                            validate: (value: string[]) =>
+                                                value.length > 0 ||
+                                                '최소 하나의 크기를 선택해주세요!',
+                                        }}
+                                    />
+                                </div>
+                                <Controller
+                                    name="mbti"
+                                    control={control}
+                                    rules={{
+                                        required: 'MBTI를 선택해주세요!',
+                                    }}
+                                    render={({ field }) => (
+                                        <SelectBox
+                                            id="mbti"
+                                            label="MBTI"
+                                            design="solid"
+                                            options={selectOptions}
+                                            value={selectedOption}
+                                            onChange={(option) => {
+                                                selectOption(option);
+                                                field.onChange(option.value);
+                                            }}
+                                            toggleSelectBox={toggleSelectBox}
+                                            isOpen={isOpen}
+                                            selectBoxRef={selectBoxRef}
+                                            error={errors.mbti?.message}
+                                        />
+                                    )}
+                                />
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+            <footer
+                className={`w-full max-w-[600px] px-6 py-2.5 mx-auto ${pageNumber !== 4 && 'hidden'}`}
+            >
+                <button
+                    type="submit"
+                    form="signup-form"
+                    className="btn-solid mb-8"
+                    disabled={
+                        !!errors.dogSizes?.message || !!errors.mbti?.message
+                    }
+                >
+                    다음
+                </button>
+            </footer>
+        </>
+    );
+}

--- a/src/components/signup/SecondStep.tsx
+++ b/src/components/signup/SecondStep.tsx
@@ -39,7 +39,8 @@ export default function SecondStep({
     const handleNextBtn = useCallback(() => {
         // api 요청
         console.log('2번 페이지 성공');
-        setPageNumber(3);
+        // react-hook-form의 submit 함수와의 충돌 방지
+        setPageNumber((prev) => prev + 1);
     }, []);
 
     return (
@@ -96,8 +97,7 @@ export default function SecondStep({
                 className={`w-full max-w-[600px] px-6 py-2.5 mx-auto ${pageNumber !== 2 && 'hidden'}`}
             >
                 <button
-                    type="submit"
-                    form="signup-form"
+                    form="none"
                     className="btn-solid mb-8"
                     disabled={
                         password === '' ||

--- a/src/components/signup/ThirdStep.tsx
+++ b/src/components/signup/ThirdStep.tsx
@@ -98,8 +98,7 @@ export default function ThirdStep({
                 className={`w-full max-w-[600px] px-6 py-2.5 mx-auto ${pageNumber !== 3 && 'hidden'}`}
             >
                 <button
-                    type="submit"
-                    form="signup-form"
+                    form="none"
                     className="btn-solid mb-8"
                     disabled={
                         nickname === '' ||

--- a/src/components/signup/ThirdStep.tsx
+++ b/src/components/signup/ThirdStep.tsx
@@ -1,0 +1,117 @@
+import {
+    introduceValidationType,
+    nicknameValidationType,
+    SignUpInputs,
+} from '@/hooks/useSignupForm';
+import { CustomInput, ImageSelectBox } from '../common';
+import { FieldErrors, UseFormRegister, UseFormWatch } from 'react-hook-form';
+import { useCallback } from 'react';
+
+interface ThirdStepPropsType {
+    pageNumber: number;
+    register: UseFormRegister<SignUpInputs>;
+    watch: UseFormWatch<SignUpInputs>;
+    nicknameValidation: nicknameValidationType;
+    introduceValidation: introduceValidationType;
+    errors: FieldErrors<SignUpInputs>;
+    setPageNumber: React.Dispatch<React.SetStateAction<number>>;
+    imgName: string;
+    setImgName: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function ThirdStep({
+    pageNumber,
+    register,
+    watch,
+    nicknameValidation,
+    introduceValidation,
+    errors,
+    setPageNumber,
+    imgName,
+    setImgName,
+}: ThirdStepPropsType) {
+    const nickname = watch('nickname');
+    const introduce = watch('introduce');
+
+    const handleNextBtn = useCallback(() => {
+        // api 요청
+        console.log('3번 페이지 성공');
+        setPageNumber((prev) => prev + 1);
+    }, []);
+
+    return (
+        <>
+            <div className={`${pageNumber !== 3 && 'hidden'}`}>
+                {/* 프로그래스바 */}
+                <div className="w-full bg-white h-1">
+                    <div className="bg-point-400 h-1 w-[75%]"></div>
+                </div>
+                <div className="bg-white pt-6 pb-1">
+                    <div className="w-full max-w-[600px] px-6 mx-auto">
+                        <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                            <p>어떤 프로필로</p>
+                            <p>대화할까요?</p>
+                        </div>
+                        {pageNumber === 3 && (
+                            <div className="flex flex-col gap-1">
+                                input
+                                <ImageSelectBox
+                                    label="프로필 사진"
+                                    bottomSheetLabel="프로필 이미지를 선택하세요."
+                                    imgName={imgName}
+                                    setImgName={setImgName}
+                                />
+                                <CustomInput
+                                    id="nickname"
+                                    label="닉네임"
+                                    type="text"
+                                    placeholder="닉네임을 알려주세요."
+                                    register={register}
+                                    watch={watch}
+                                    validation={nicknameValidation}
+                                    error={errors.nickname?.message}
+                                    design="outline"
+                                    successMsg="좋아요!"
+                                />
+                                <CustomInput
+                                    id="introduce"
+                                    label="프로필 소개 (최대 50글자)"
+                                    type="textarea"
+                                    placeholder="자기소개를 작성해주세요!"
+                                    register={register}
+                                    watch={watch}
+                                    validation={introduceValidation}
+                                    error={errors.introduce?.message}
+                                    design="outline"
+                                    successMsg="좋아요!"
+                                />
+                                <div className="flex justify-end">
+                                    <span className="text-label-m text-gray-500">
+                                        {introduce?.length || '0'}/50
+                                    </span>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+            <footer
+                className={`w-full max-w-[600px] px-6 py-2.5 mx-auto ${pageNumber !== 3 && 'hidden'}`}
+            >
+                <button
+                    type="submit"
+                    form="signup-form"
+                    className="btn-solid mb-8"
+                    disabled={
+                        nickname === '' ||
+                        !!errors.nickname?.message ||
+                        !!errors.introduce?.message
+                    }
+                    onClick={handleNextBtn}
+                >
+                    다음
+                </button>
+            </footer>
+        </>
+    );
+}

--- a/src/components/signup/ThirdStep.tsx
+++ b/src/components/signup/ThirdStep.tsx
@@ -54,7 +54,6 @@ export default function ThirdStep({
                         </div>
                         {pageNumber === 3 && (
                             <div className="flex flex-col gap-1">
-                                input
                                 <ImageSelectBox
                                     label="프로필 사진"
                                     bottomSheetLabel="프로필 이미지를 선택하세요."

--- a/src/components/signup/index.ts
+++ b/src/components/signup/index.ts
@@ -1,2 +1,3 @@
 export { default as FirstStep } from './FirstStep';
 export { default as SecondStep } from './SecondStep';
+export { default as ThirdStep } from './ThirdStep';

--- a/src/components/signup/index.ts
+++ b/src/components/signup/index.ts
@@ -1,3 +1,4 @@
 export { default as FirstStep } from './FirstStep';
 export { default as SecondStep } from './SecondStep';
 export { default as ThirdStep } from './ThirdStep';
+export { default as FourthStep } from './FourthStep';

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 /**
@@ -12,6 +13,10 @@ export interface SignUpInputs {
     password: string;
     /** User's confirm password */
     confirmPassword: string;
+    /** User's nickname */
+    nickname: string;
+    /** User's introduce */
+    introduce: string;
 }
 
 export interface emailValidationType {
@@ -43,6 +48,29 @@ export interface confirmPasswordValidationType {
     validate: (value: string | number) => boolean | string;
 }
 
+export interface nicknameValidationType {
+    required: string;
+    minLength: {
+        value: number;
+        message: string;
+    };
+    maxLength: {
+        value: number;
+        message: string;
+    };
+    pattern: {
+        value: RegExp;
+        message: string;
+    };
+}
+
+export interface introduceValidationType {
+    maxLength: {
+        value: number;
+        message: string;
+    };
+}
+
 /**
  * Custom hook for handling signup form logic
  * @returns {Object} Form methods and handlers
@@ -53,10 +81,12 @@ export default function useSignupForm() {
         handleSubmit,
         watch,
         formState: { errors, isValid },
-        trigger,
     } = useForm<SignUpInputs>({
+        shouldFocusError: false,
         mode: 'onChange',
     });
+
+    const [pageNumber, setPageNumber] = useState(1);
 
     /**
      * Handles form submission
@@ -108,17 +138,49 @@ export default function useSignupForm() {
             value === watch('password') || '비밀번호가 일치하지 않아요!',
     };
 
+    /**
+     * nickname validation
+     */
+    const nicknameValidation = {
+        required: '닉네임은 필수입니다!',
+        minLength: {
+            value: 2,
+            message: '닉네임은 최소 2자 이상이어야 합니다!',
+        },
+        maxLength: {
+            value: 10,
+            message: '닉네임은 최대 10자 이하이어야 합니다!',
+        },
+        pattern: {
+            value: /^[^\d]/,
+            message: '닉네임은 숫자로 시작할 수 없습니다!',
+        },
+    };
+
+    /**
+     * introduce validation
+     */
+    const introduceValidation = {
+        maxLength: {
+            value: 50,
+            message: '자기소개는 최대 50자 이하이어야 합니다!',
+        },
+    };
+
     return {
+        pageNumber,
+        setPageNumber,
         emailValidation,
         verificationCodeValidation,
         passwordValidation,
         confirmPasswordValidation,
+        nicknameValidation,
+        introduceValidation,
         register,
         handleSubmit,
         watch,
         errors,
         onSubmit,
-        trigger,
         isValid,
     };
 }

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -17,6 +17,10 @@ export interface SignUpInputs {
     nickname: string;
     /** User's introduce */
     introduce: string;
+    /** User's preference of dog sizes */
+    dogSizes: string[];
+    /** User's mbti */
+    mbti: string;
 }
 
 export interface emailValidationType {
@@ -81,6 +85,7 @@ export default function useSignupForm() {
         handleSubmit,
         watch,
         formState: { errors, isValid },
+        control,
     } = useForm<SignUpInputs>({
         shouldFocusError: false,
         mode: 'onChange',
@@ -182,5 +187,6 @@ export default function useSignupForm() {
         errors,
         onSubmit,
         isValid,
+        control,
     };
 }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,26 +1,28 @@
 import Back from '@/assets/images/header/back.svg?react';
-import { FirstStep, SecondStep } from '@/components/signup';
-
+import { FirstStep, SecondStep, ThirdStep } from '@/components/signup';
 import { useFadeNavigate, useSignupForm } from '@/hooks';
 import { useCallback, useState } from 'react';
 
 export default function Signup() {
     const navigate = useFadeNavigate();
     const {
+        pageNumber,
+        setPageNumber,
         emailValidation,
         verificationCodeValidation,
         passwordValidation,
         confirmPasswordValidation,
+        nicknameValidation,
+        introduceValidation,
         register,
         handleSubmit,
         watch,
         errors,
         onSubmit,
-        trigger,
         isValid,
     } = useSignupForm();
 
-    const [pageNumber, setPageNumber] = useState(1);
+    const [imgName, setImgName] = useState('profile=1');
 
     const handleBackBtn = useCallback(() => {
         if (pageNumber === 1) {
@@ -53,7 +55,6 @@ export default function Signup() {
                     emailValidation={emailValidation}
                     verificationCodeValidation={verificationCodeValidation}
                     errors={errors}
-                    trigger={trigger}
                     isValid={isValid}
                     setPageNumber={setPageNumber}
                 />
@@ -65,6 +66,17 @@ export default function Signup() {
                     confirmPasswordValidation={confirmPasswordValidation}
                     errors={errors}
                     setPageNumber={setPageNumber}
+                />
+                <ThirdStep
+                    pageNumber={pageNumber}
+                    register={register}
+                    watch={watch}
+                    nicknameValidation={nicknameValidation}
+                    introduceValidation={introduceValidation}
+                    errors={errors}
+                    setPageNumber={setPageNumber}
+                    imgName={imgName}
+                    setImgName={setImgName}
                 />
             </form>
         </div>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,10 @@
 import Back from '@/assets/images/header/back.svg?react';
-import { FirstStep, SecondStep, ThirdStep } from '@/components/signup';
+import {
+    FirstStep,
+    FourthStep,
+    SecondStep,
+    ThirdStep,
+} from '@/components/signup';
 import { useFadeNavigate, useSignupForm } from '@/hooks';
 import { useCallback, useState } from 'react';
 
@@ -20,6 +25,7 @@ export default function Signup() {
         errors,
         onSubmit,
         isValid,
+        control,
     } = useSignupForm();
 
     const [imgName, setImgName] = useState('profile=1');
@@ -77,6 +83,13 @@ export default function Signup() {
                     setPageNumber={setPageNumber}
                     imgName={imgName}
                     setImgName={setImgName}
+                />
+                <FourthStep
+                    pageNumber={pageNumber}
+                    register={register}
+                    watch={watch}
+                    errors={errors}
+                    control={control}
                 />
             </form>
         </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

회원가입은 총 4단계의 절차를 걸쳐 가입이 완료됩니다.
그 중 3,4 단계 컴포넌트를 작성하였습니다.

## 📌 이슈 넘버

- #45 

## 📝 작업 내용

- 회원가입 페이지 컴포넌트 코드 추가
- 회원가입 커스텀 훅 코드 추가
- 회원가입 3단계 컴포넌트 작성
- 회원가입 4단계 컴포넌트 작성

## 📸 스크린샷(선택)

![chrome-capture-2024-11-26](https://github.com/user-attachments/assets/66d66676-12de-42fe-b812-d66ca95fbf5f)
