### PR TITLE
[Feat]  동물등록 step3 구현

### DIFF
--- a/src/components/register/RegisterStep3.tsx
+++ b/src/components/register/RegisterStep3.tsx
@@ -1,164 +1,124 @@
-import { useState } from 'react';
-
-interface RegisterStep3Props {
-    onNext: () => void;
-    updateFormData: (field: string, value: string) => void;
-}
+import { CustomInput, CustomToggle, MultiSelectTag } from '../common';
+import { ToastAnchor } from '@/components/common';
+import { RegisterStep3Props } from '@/types/register';
 
 export default function RegisterStep3({
     onNext,
-    updateFormData,
+    register,
+    watch,
+    errors,
+    control,
+    getValue,
 }: RegisterStep3Props) {
-    const [answers, setAnswers] = useState({
-        first: '', // E or I
-        second: '', // S or N
-        third: '', // F or T
-        fourth: '', // P or J
-    });
+    const dogSizeOptions = [
+        { value: 'small', label: '소형견' },
+        { value: 'medium', label: '중형견' },
+        { value: 'large', label: '대형견' },
+    ];
 
-    const handleAnswer = (question: string, value: string) => {
-        setAnswers((prev) => ({
-            ...prev,
-            [question]: value,
-        }));
+    const neutered = watch('neutered');
+    const size = watch('size');
+    const age = watch('age');
+
+    // 나이 validation
+    const ageValidation = {
+        required: '나이는 필수 입력사항입니다.',
+        pattern: {
+            value: /^[0-9]+$/,
+            message: '숫자만 입력 가능합니다',
+        },
     };
 
-    const handleSubmit = () => {
-        // DMBTI 계산
-        const dmbti = `${answers.first}${answers.second}${answers.third}${answers.fourth}`;
-        updateFormData('dmbti', dmbti); // 상태 업데이트
-        onNext(); // 다음 단계로 이동
+    const isNextButtonDisabled =
+        !age || !size?.length || neutered === undefined;
+
+    const handleNext = () => {
+        if (getValue) {
+            console.log(getValue());
+        }
+        onNext();
     };
 
     return (
-        <div>
-            <p className="text-lg py-4 font-extrabold">
-                애견의 성향을 입력해주세요.
-            </p>
+        <div className="flex flex-col justify-between h-full">
+            {/* 프로그래스바 */}
+            <div className="w-full bg-white h-1">
+                <div className="bg-point-400 h-1 w-[75%]"></div>
+            </div>
 
-            {/* Question 1 */}
-            <div className="mb-4">
-                <p>새로운 사람이나 애견 친구를 만나면 금방 친해지나요?</p>
-                <div className="flex gap-4">
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.first === 'E'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('first', 'E')}
-                    >
-                        예 (E)
-                    </button>
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.first === 'I'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('first', 'I')}
-                    >
-                        아니오 (I)
-                    </button>
+            <section className="flex flex-col w-full flex-1">
+                <div className="bg-white pt-6 pb-12 flex flex-col">
+                    <div className="w-full max-w-[600px] px-6 mx-auto">
+                        <h1 className="mb-12 text-title-s text-gray-800 font-extrabold">
+                            멍멍이의
+                            <br /> 추가 정보를 알려주세요
+                        </h1>
+
+                        {/* 중성화 여부 */}
+                        <div className="flex flex-col gap-7 mb-4">
+                            <CustomToggle
+                                name="neutered"
+                                label="중성화 여부"
+                                leftText="Yes"
+                                rightText="No"
+                                register={register}
+                                watch={watch}
+                            />
+
+                            {/* 애견 크기 */}
+                            <MultiSelectTag
+                                label="애견 크기"
+                                name="size"
+                                options={dogSizeOptions}
+                                control={control}
+                                rules={{
+                                    required: '크기를 선택해주세요!',
+                                    validate: (value: string[]) =>
+                                        value.length > 0 ||
+                                        '크기를 선택해주세요!',
+                                }}
+                            />
+
+                            {/* 나이 입력 */}
+                            <CustomInput
+                                id="age"
+                                label="나이"
+                                placeholder="나이를 연 단위로 입력해주세요 (예: 3)"
+                                register={register}
+                                watch={watch}
+                                validation={ageValidation}
+                                error={errors.age?.message?.toString()}
+                                design="outline"
+                                successMsg=""
+                            />
+
+                            {/* 선호 산책 장소 입력 */}
+                            <CustomInput
+                                id="favoritePlace"
+                                label="선호 산책 장소"
+                                placeholder="(선택)선호 산책 장소를 입력해주세요"
+                                register={register}
+                                watch={watch}
+                                design="outline"
+                                successMsg=""
+                            />
+                        </div>
+                    </div>
                 </div>
-            </div>
+            </section>
 
-            {/* Question 2 */}
-            <div className="mb-4">
-                <p>산책 중 새로운 냄새를 맡으면 바로 반응하나요?</p>
-                <div className="flex gap-4">
+            <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto">
+                <ToastAnchor>
                     <button
-                        className={`px-4 py-2 rounded ${
-                            answers.second === 'S'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('second', 'S')}
+                        type="button"
+                        className="btn-solid w-full"
+                        onClick={handleNext}
+                        disabled={isNextButtonDisabled}
                     >
-                        예 (S)
+                        다음
                     </button>
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.second === 'N'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('second', 'N')}
-                    >
-                        아니오 (N)
-                    </button>
-                </div>
-            </div>
-
-            {/* Question 3 */}
-            <div className="mb-4">
-                <p>애견이 주인의 기분 변화에 민감하게 반응하나요?</p>
-                <div className="flex gap-4">
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.third === 'F'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('third', 'F')}
-                    >
-                        예 (F)
-                    </button>
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.third === 'T'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('third', 'T')}
-                    >
-                        아니오 (T)
-                    </button>
-                </div>
-            </div>
-
-            {/* Question 4 */}
-            <div className="mb-4">
-                <p>애견이 산책 중 우연히 발견한 것에 강한 호기심을 보이나요?</p>
-                <div className="flex gap-4">
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.fourth === 'P'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('fourth', 'P')}
-                    >
-                        예 (P)
-                    </button>
-                    <button
-                        className={`px-4 py-2 rounded ${
-                            answers.fourth === 'J'
-                                ? 'bg-point-500 text-white'
-                                : 'bg-gray-200 text-gray-500'
-                        }`}
-                        onClick={() => handleAnswer('fourth', 'J')}
-                    >
-                        아니오 (J)
-                    </button>
-                </div>
-            </div>
-
-            {/* Submit Button */}
-            <div className="fixed py-2.5 bottom-0 w-full left-0 px-4">
-                <button
-                    className="btn-solid bg-point-500 w-full py-2 text-white"
-                    onClick={handleSubmit}
-                    disabled={
-                        !answers.first ||
-                        !answers.second ||
-                        !answers.third ||
-                        !answers.fourth
-                    } // 모든 질문에 응답해야 활성화
-                >
-                    DMBTI 완료
-                </button>
-            </div>
+                </ToastAnchor>
+            </footer>
         </div>
     );
 }

--- a/src/components/register/RegisterStep4.tsx
+++ b/src/components/register/RegisterStep4.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+
+interface RegisterStep4Props {
+    onNext: () => void;
+    updateFormData: (field: string, value: string) => void;
+}
+
+export default function RegisterStep4({
+    onNext,
+    updateFormData,
+}: RegisterStep4Props) {
+    const [answers, setAnswers] = useState({
+        first: '', // E or I
+        second: '', // S or N
+        third: '', // F or T
+        fourth: '', // P or J
+    });
+
+    const handleAnswer = (question: string, value: string) => {
+        setAnswers((prev) => ({
+            ...prev,
+            [question]: value,
+        }));
+    };
+
+    const handleSubmit = () => {
+        // DMBTI 계산
+        const dmbti = `${answers.first}${answers.second}${answers.third}${answers.fourth}`;
+        updateFormData('dmbti', dmbti); // 상태 업데이트
+        onNext(); // 다음 단계로 이동
+    };
+
+    return (
+        <div>
+            <p className="text-lg py-4 font-extrabold">
+                애견의 성향을 입력해주세요.
+            </p>
+
+            {/* Question 1 */}
+            <div className="mb-4">
+                <p>새로운 사람이나 애견 친구를 만나면 금방 친해지나요?</p>
+                <div className="flex gap-4">
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.first === 'E'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('first', 'E')}
+                    >
+                        예 (E)
+                    </button>
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.first === 'I'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('first', 'I')}
+                    >
+                        아니오 (I)
+                    </button>
+                </div>
+            </div>
+
+            {/* Question 2 */}
+            <div className="mb-4">
+                <p>산책 중 새로운 냄새를 맡으면 바로 반응하나요?</p>
+                <div className="flex gap-4">
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.second === 'S'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('second', 'S')}
+                    >
+                        예 (S)
+                    </button>
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.second === 'N'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('second', 'N')}
+                    >
+                        아니오 (N)
+                    </button>
+                </div>
+            </div>
+
+            {/* Question 3 */}
+            <div className="mb-4">
+                <p>애견이 주인의 기분 변화에 민감하게 반응하나요?</p>
+                <div className="flex gap-4">
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.third === 'F'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('third', 'F')}
+                    >
+                        예 (F)
+                    </button>
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.third === 'T'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('third', 'T')}
+                    >
+                        아니오 (T)
+                    </button>
+                </div>
+            </div>
+
+            {/* Question 4 */}
+            <div className="mb-4">
+                <p>애견이 산책 중 우연히 발견한 것에 강한 호기심을 보이나요?</p>
+                <div className="flex gap-4">
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.fourth === 'P'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('fourth', 'P')}
+                    >
+                        예 (P)
+                    </button>
+                    <button
+                        className={`px-4 py-2 rounded ${
+                            answers.fourth === 'J'
+                                ? 'bg-point-500 text-white'
+                                : 'bg-gray-200 text-gray-500'
+                        }`}
+                        onClick={() => handleAnswer('fourth', 'J')}
+                    >
+                        아니오 (J)
+                    </button>
+                </div>
+            </div>
+
+            {/* Submit Button */}
+            <div className="fixed py-2.5 bottom-0 w-full left-0 px-4">
+                <button
+                    className="btn-solid bg-point-500 w-full py-2 text-white"
+                    onClick={handleSubmit}
+                    disabled={
+                        !answers.first ||
+                        !answers.second ||
+                        !answers.third ||
+                        !answers.fourth
+                    } // 모든 질문에 응답해야 활성화
+                >
+                    DMBTI 완료
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/register/index.ts
+++ b/src/components/register/index.ts
@@ -1,5 +1,6 @@
 export { default as RegisterStep1 } from './RegisterStep1';
 export { default as RegisterStep2 } from './RegisterStep2';
 export { default as RegisterStep3 } from './RegisterStep3';
+export { default as RegisterStep4 } from './RegisterStep4';
 export { default as RegisterComplete } from './RegisterComplete';
 export { default as StepIndicator } from './StepIndicator';

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -7,6 +7,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { RegisterStep1 } from '@/components/register';
 import { RegisterStep2 } from '@/components/register';
 import { RegisterStep3 } from '@/components/register';
+import { RegisterStep4 } from '@/components/register';
 import { RegisterComplete } from '@/components/register';
 import { RegisterFormData } from '@/types/register';
 
@@ -52,7 +53,7 @@ export default function Register() {
 
     const handleNextStep = async () => {
         const isStepValid = await trigger();
-        if (isStepValid && step < 4) {
+        if (isStepValid && step < 5) {
             setStep((prevStep) => prevStep + 1);
         }
     };
@@ -74,7 +75,7 @@ export default function Register() {
             onSubmit={handleSubmit(onSubmit)}
             className="min-h-screen bg-gray-100 flex flex-col items-center justify-between overflow-hidden"
         >
-            {step < 4 ? (
+            {step < 5 ? (
                 <header className="bg-white h-14 w-full flex items-center justify-center">
                     <Back
                         onClick={handleBackBtn}
@@ -149,6 +150,22 @@ export default function Register() {
                         </motion.div>
                     )}
                     {step === 4 && (
+                        <motion.div
+                            key="step4"
+                            className="w-full"
+                            initial="initial"
+                            animate="animate"
+                            exit="exit"
+                            variants={pageVariants}
+                            transition={{ duration: 0.5 }}
+                        >
+                            <RegisterStep4
+                                onNext={handleNextStep}
+                                updateFormData={getValues}
+                            />
+                        </motion.div>
+                    )}
+                    {step === 5 && (
                         <motion.div
                             key="complete"
                             className="w-full flex flex-col items-center justify-center"

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useFadeNavigate } from '@/hooks';
 import Back from '@/assets/images/header/back.svg?react';
@@ -37,12 +37,24 @@ export default function Register() {
             age: '',
             favoritePlace: '',
             gender: '',
-            neutered: '',
+            neutered: false,
             size: '',
             dmbti: '',
             dogImg: 'profile1', // 기본 이미지
         },
     });
+
+    // Step3에서 neutered 값이 "미중성"으로 설정될 때를 처리하는 로직
+    useEffect(() => {
+        if (step === 3) {
+            const currentNeutered = getValues('neutered');
+            if (currentNeutered === '미중성') {
+                setValue('neutered', false);
+            } else if (currentNeutered === '중성') {
+                setValue('neutered', true);
+            }
+        }
+    }, [step]);
 
     const handleBackBtn = useCallback(() => {
         if (step > 1) {
@@ -109,7 +121,7 @@ export default function Register() {
                                 register={register}
                                 errors={errors}
                                 watch={watch}
-                                // getValue={getValues}
+                                getValue={getValues}
                                 setValue={setValue}
                             />
                         </motion.div>
@@ -151,7 +163,6 @@ export default function Register() {
                                 watch={watch}
                                 errors={errors}
                                 getValue={getValues}
-                                setValue={setValue}
                             />
                         </motion.div>
                     )}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -7,6 +7,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { RegisterStep1 } from '@/components/register';
 import { RegisterStep2 } from '@/components/register';
 import { RegisterStep3 } from '@/components/register';
+import { RegisterStep4 } from '@/components/register';
 import { RegisterComplete } from '@/components/register';
 import { RegisterFormData } from '@/types/register';
 
@@ -22,6 +23,7 @@ export default function Register() {
         handleSubmit,
         watch,
         trigger,
+        control,
         formState: { errors },
         getValues,
         setValue,
@@ -52,7 +54,7 @@ export default function Register() {
 
     const handleNextStep = async () => {
         const isStepValid = await trigger();
-        if (isStepValid && step < 4) {
+        if (isStepValid && step < 5) {
             setStep((prevStep) => prevStep + 1);
         }
     };
@@ -74,7 +76,7 @@ export default function Register() {
             onSubmit={handleSubmit(onSubmit)}
             className="min-h-screen bg-gray-100 flex flex-col items-center justify-between overflow-hidden"
         >
-            {step < 4 ? (
+            {step < 5 ? (
                 <header className="bg-white h-14 w-full flex items-center justify-center">
                     <Back
                         onClick={handleBackBtn}
@@ -144,11 +146,32 @@ export default function Register() {
                         >
                             <RegisterStep3
                                 onNext={handleNextStep}
-                                updateFormData={getValues}
+                                register={register}
+                                control={control}
+                                watch={watch}
+                                errors={errors}
+                                getValue={getValues}
+                                setValue={setValue}
                             />
                         </motion.div>
                     )}
                     {step === 4 && (
+                        <motion.div
+                            key="step4"
+                            className="w-full"
+                            initial="initial"
+                            animate="animate"
+                            exit="exit"
+                            variants={pageVariants}
+                            transition={{ duration: 0.5 }}
+                        >
+                            <RegisterStep4
+                                onNext={handleNextStep}
+                                updateFormData={getValues}
+                            />
+                        </motion.div>
+                    )}
+                    {step === 5 && (
                         <motion.div
                             key="complete"
                             className="w-full flex flex-col items-center justify-center"

--- a/src/types/register.d.ts
+++ b/src/types/register.d.ts
@@ -8,7 +8,7 @@ export interface RegisterFormData {
     age: string;
     favoritePlace: string;
     gender: string;
-    neutered: string;
+    neutered: string | boolean; //open api: string, post api: boolean
     size: string;
     dmbti: string;
     dogImg: string;
@@ -19,7 +19,7 @@ export interface RegisterStep1Props {
     register: UseFormRegister<RegisterFormData>;
     watch: UseFormWatch<RegisterFormData>;
     errors: FieldErrors<RegisterFormData>;
-    // getValue: UseFormGetValues<RegisterFormData>;
+    getValue?: UseFormGetValues<RegisterFormData>;
     setValue: UseFormSetValue<RegisterFormData>;
 }
 
@@ -59,4 +59,13 @@ export interface RegisterStep2Props {
     setValue: UseFormSetValue<RegisterFormData>;
     imgName: string;
     setImgName: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export interface RegisterStep3Props {
+    onNext: () => void;
+    register: UseFormRegister<RegisterFormData>;
+    watch: UseFormWatch<RegisterFormData>;
+    errors: FieldErrors<RegisterFormData>;
+    control: Control<RegisterFormData, any>;
+    getValue?: UseFormWatch<RegisterFormData>;
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

동물등록 step3 구현

## 📌 이슈 넘버

- #79 

## 📝 작업 내용

- step3 UI 퍼블리싱
- step3 커스텀 toggle, multi-select 컴포넌트 이용
- step3의 중성화 여부의 default값은 등록번호 조회 단계(step1)의 응답값을 default로 활용하도록 설정하였습니다.
- 선호 산책 장소는 option으로 처리하였습니다.
- 나이는 number만 입력할 수 있도록 placeholder과 유효성 검사를 설정해두었습니다.
- option 값을 제외하고 모든 input이 입력될 시 '다음'버튼이 활성화됩니다.

## 📸 스크린샷(선택)
1. 중성화여부가 '중성(중성화O)'인 강아지 인 경우, toggle 의 default 값이 'Yes'로 설정됨.
![chrome-capture-2024-11-28 (3)](https://github.com/user-attachments/assets/ae50c779-3fa2-4636-813b-2c19fdceec1c)

2. 중성화여부가 '미중성(중성화X)'인 강아지 인 경우, toggle 의 default 값이 'No'로 설정됨.
![chrome-capture-2024-11-28 (4)](https://github.com/user-attachments/assets/3ee8eae5-d4e6-40e1-bc3a-07ea6659ba50)

## 💬리뷰 요구사항(선택)

step1에서 조회 api loading 처리를 깜박해서,
중요한 것은 아니므로 step4까지 진행 후 추후 처리하겠습니다.!