### PR TITLE
[Feat] 회원가입 페이지 이메일 인증코드 api 연동

### DIFF
--- a/src/components/signup/FirstStep.tsx
+++ b/src/components/signup/FirstStep.tsx
@@ -3,7 +3,7 @@ import {
     SignUpInputs,
     verificationCodeValidationType,
 } from '@/hooks/useSignupForm';
-import { CustomInput } from '../common';
+import { CustomInput, ToastAnchor, useCustomToast } from '../common';
 import { FieldErrors, UseFormRegister, UseFormWatch } from 'react-hook-form';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { postEmailVerificationCode } from '@/hooks/api/signup';
@@ -32,6 +32,7 @@ export default function FirstStep({
     const emailTyped = useRef(false);
     const [sentNumber, setSentNumber] = useState(false);
     const [firstVisit, setFirstVisit] = useState(true);
+    const { showToast } = useCustomToast();
 
     const email = watch('email');
     const verificationCode = watch('verificationCode');
@@ -47,12 +48,12 @@ export default function FirstStep({
         await postEmailVerificationCode({ accountId }).then((response) => {
             if (response.ok) {
                 setSentNumber(true);
-                // 토스트
+                showToast('인증코드를 전송하였습니다!', 'success');
             } else {
                 if (response.error?.status === 400) {
-                    // 토스트
+                    showToast('이미 사용하고 있는 이메일입니다!', 'warning');
                 } else {
-                    // 토스트
+                    showToast('서버 연결 문제가 발생했습니다!', 'warning');
                 }
             }
         });
@@ -94,18 +95,20 @@ export default function FirstStep({
                                         successMsg="좋아요!"
                                     />
                                 </div>
-                                <button
-                                    form="none"
-                                    className="btn-solid btn-md"
-                                    disabled={
-                                        (!emailTyped.current && !isValid) ||
-                                        !!errors.email ||
-                                        email === ''
-                                    }
-                                    onClick={handleVerificateEmailBtn}
-                                >
-                                    {firstVisit ? '인증번호' : '재요청'}
-                                </button>
+                                <ToastAnchor>
+                                    <button
+                                        form="none"
+                                        className="btn-solid btn-md"
+                                        disabled={
+                                            (!emailTyped.current && !isValid) ||
+                                            !!errors.email ||
+                                            email === ''
+                                        }
+                                        onClick={handleVerificateEmailBtn}
+                                    >
+                                        {firstVisit ? '인증번호' : '재요청'}
+                                    </button>
+                                </ToastAnchor>
                             </div>
                             <div className="flex gap-2 items-center">
                                 <div className="flex-1">

--- a/src/components/signup/FirstStep.tsx
+++ b/src/components/signup/FirstStep.tsx
@@ -6,6 +6,7 @@ import {
 import { CustomInput } from '../common';
 import { FieldErrors, UseFormRegister, UseFormWatch } from 'react-hook-form';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { postEmailVerificationCode } from '@/hooks/api/signup';
 
 interface FirstStepPropsType {
     pageNumber: number;
@@ -39,11 +40,23 @@ export default function FirstStep({
         emailTyped.current = true;
     });
 
-    const handleVerificateEmailBtn = useCallback(() => {
+    const handleVerificateEmailBtn = useCallback(async () => {
         setFirstVisit(false);
         // api 요청
-        setSentNumber(true);
-    }, []);
+        const accountId = email;
+        await postEmailVerificationCode({ accountId }).then((response) => {
+            if (response.ok) {
+                setSentNumber(true);
+                // 토스트
+            } else {
+                if (response.error?.status === 400) {
+                    // 토스트
+                } else {
+                    // 토스트
+                }
+            }
+        });
+    }, [email]);
 
     const handleNextBtn = useCallback(() => {
         // api 요청

--- a/src/components/signup/FirstStep.tsx
+++ b/src/components/signup/FirstStep.tsx
@@ -32,6 +32,7 @@ export default function FirstStep({
     const emailTyped = useRef(false);
     const [sentNumber, setSentNumber] = useState(false);
     const [firstVisit, setFirstVisit] = useState(true);
+    const [loading, setLoading] = useState(false);
     const { showToast } = useCustomToast();
 
     const email = watch('email');
@@ -42,6 +43,8 @@ export default function FirstStep({
     });
 
     const handleVerificateEmailBtn = useCallback(async () => {
+        if (loading) return;
+        setLoading(true);
         setFirstVisit(false);
         // api 요청
         const accountId = email;
@@ -57,7 +60,8 @@ export default function FirstStep({
                 }
             }
         });
-    }, [email]);
+        setLoading(false);
+    }, [email, loading]);
 
     const handleNextBtn = useCallback(() => {
         // api 요청

--- a/src/hooks/api/signup.ts
+++ b/src/hooks/api/signup.ts
@@ -1,0 +1,19 @@
+import {
+    EmailVerificationCodeApiRequest,
+    EmailVerificationCodeApiResponse,
+} from '@/types/signup';
+import { http } from './base';
+
+/**
+ * POSTT	Send VerificationCode to Email
+ * 해당 이메일로 인증코드를 보냅니다.
+ */
+export const postEmailVerificationCode = async ({
+    accountId,
+}: EmailVerificationCodeApiRequest): Promise<EmailVerificationCodeApiResponse> =>
+    await http.post<
+        EmailVerificationCodeApiResponse,
+        EmailVerificationCodeApiRequest
+    >('/api/auth/email-certification', {
+        accountId,
+    });

--- a/src/types/signup.d.ts
+++ b/src/types/signup.d.ts
@@ -1,0 +1,17 @@
+import { BaseApiResponse } from './baseResponse';
+
+//	POST Send VerificationCode to Email
+interface EmailVerificationCodeApiRequest {
+    accountId: string;
+}
+interface EmailVerificationCodeApiResponse extends BaseApiResponse {
+    data: {
+        responseCode: string;
+        message: string;
+    };
+}
+
+export type {
+    EmailVerificationCodeApiRequest,
+    EmailVerificationCodeApiResponse,
+};


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

회원가입 1단계에서 이메일로 인증코드를 전송하도록 API 요청을 추가

## 📌 이슈 넘버

- #83 

## 📝 작업 내용

- API 요청 코드 추가
- 다양한 응답에 대한 토스트 렌더링
- API 테스트

## 이슈 발생

공통 커스텀 토스트 컴포넌트 디자인 수정이 필요
![chrome-capture-2024-11-28](https://github.com/user-attachments/assets/d51cc185-f70f-4e79-8c97-eca7112b9a19)
