### PR TITLE
[Feat] 매칭 기능 API 연동 로직 작성

### DIFF
--- a/src/components/match/MatchCard.tsx
+++ b/src/components/match/MatchCard.tsx
@@ -1,7 +1,6 @@
 import { motion } from 'framer-motion';
 import useMatchStore, { MatchWidthColor } from '@/stores/useMatchStore';
 import { useFadeNavigate } from '@/hooks';
-import { useState } from 'react';
 
 // SVG
 import ArrowRightIcon from '@/assets/images/arrow/arrowRight.svg?react';
@@ -14,7 +13,7 @@ interface MatchCardProps {
     card: MatchWidthColor;
     index: number;
     zIndex: number;
-    onDragEnd: (id: string) => void;
+    onDragEnd: (id: number) => void;
 }
 
 export default function MatchCard({

--- a/src/components/match/NoMoreCard.tsx
+++ b/src/components/match/NoMoreCard.tsx
@@ -1,0 +1,36 @@
+import { motion } from 'framer-motion';
+
+// SVG
+import DogLargeIcon from '@/assets/images/dogs/dogLarge.svg?react';
+
+export default function NoMoreCard() {
+    return (
+        <motion.div
+            className="absolute w-[240px] h-[375px] bg-gray-300 shadow-md rounded-xl flex flex-col items-center justify-center gap-[32px] border-1 border-point-100 text-gray-100"
+            initial={{
+                scale: 0.75,
+                y: 65.5,
+                opacity: 1,
+            }}
+            animate={{
+                y: 0,
+                scale: 1,
+                opacity: 1,
+            }}
+            transition={{ duration: 0.5 }}
+        >
+            <div className="flex flex-col items-center justify-center w-[111.5px] gap-[8px]">
+                <span className="text-center text-body-l font-extrabold">
+                    매칭 가능한
+                </span>
+                <span className="text-center text-body-l font-extrabold">
+                    돌봄이를
+                </span>
+                <span className="text-center text-body-l font-extrabold">
+                    찾을 수 없어요.
+                </span>
+            </div>
+            <DogLargeIcon className="w-[111.5px] h-[120px]" />
+        </motion.div>
+    );
+}

--- a/src/components/match/index.ts
+++ b/src/components/match/index.ts
@@ -1,3 +1,4 @@
 export { default as MatchCard } from './MatchCard';
 export { default as fetchMatchList } from './FetchMoreCard';
 export { default as IntroMatch } from './IntroMatch';
+export { default as NoMoreCard } from './NoMoreCard';

--- a/src/hooks/api/base.ts
+++ b/src/hooks/api/base.ts
@@ -22,7 +22,11 @@ export const http = {
     ): Promise<T> {
         try {
             const response = await service.get<T>(url, { params });
-            return { ok: true, data: response.data } as T;
+            return {
+                ok: true,
+                status: response.status,
+                data: response.data,
+            } as T;
         } catch (error: any) {
             return {
                 ok: false,
@@ -42,7 +46,11 @@ export const http = {
     ): Promise<T> {
         try {
             const response = await service.post<T>(url, data);
-            return { ok: true, data: response.data } as T;
+            return {
+                ok: true,
+                status: response.status,
+                data: response.data,
+            } as T;
         } catch (error: any) {
             return {
                 ok: false,
@@ -59,7 +67,11 @@ export const http = {
     delete: async function remove<T>(url: string): Promise<T> {
         try {
             const response = await service.delete<T>(url);
-            return { ok: true, data: response.data } as T;
+            return {
+                ok: true,
+                status: response.status,
+                data: response.data,
+            } as T;
         } catch (error: any) {
             return {
                 ok: false,
@@ -79,7 +91,11 @@ export const http = {
     ): Promise<T> {
         try {
             const response = await service.put<T>(url, data);
-            return { ok: true, data: response.data } as T;
+            return {
+                ok: true,
+                status: response.status,
+                data: response.data,
+            } as T;
         } catch (error: any) {
             return {
                 ok: false,
@@ -99,7 +115,11 @@ export const http = {
     ): Promise<T> {
         try {
             const response = await service.patch<T>(url, data);
-            return { ok: true, data: response.data } as T;
+            return {
+                ok: true,
+                status: response.status,
+                data: response.data,
+            } as T;
         } catch (error: any) {
             return {
                 ok: false,

--- a/src/hooks/api/match.ts
+++ b/src/hooks/api/match.ts
@@ -1,0 +1,37 @@
+import {
+    MatchFailApiRequest,
+    MatchListApiRequest,
+    MatchListApiResponse,
+} from '@/types/match';
+import { http } from './base';
+import { BaseApiResponse } from '@/types/baseResponse';
+
+/**
+ * GET MatchList
+ * 매칭 리스트를 가져옵니다.
+ */
+export const getMatchList = async ({
+    userId,
+    page,
+    size,
+}: MatchListApiRequest): Promise<MatchListApiResponse> =>
+    await http.get<MatchListApiResponse, MatchListApiRequest>(
+        '/api/match/showmetz',
+        { userId, page, size },
+    );
+
+/**
+ * POST	MatchFail
+ * 상대 유저에 대한 매칭 거부의사를 POST 합니다.
+ */
+export const postMatchFail = async ({
+    userId,
+    targetUserId,
+}: MatchFailApiRequest): Promise<BaseApiResponse> =>
+    await http.post<BaseApiResponse, MatchFailApiRequest>(
+        '/api/match/matchfail',
+        {
+            userId,
+            targetUserId,
+        },
+    );

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -1,22 +1,25 @@
 import ReactDOM from 'react-dom';
-import { useMatchStore } from '@/stores';
+import { useMatchStore, useUserStore } from '@/stores';
 import { AnimatePresence } from 'framer-motion';
 import { useEffect, useState } from 'react';
-import { IntroMatch, MatchCard } from '@/components/match';
+import { IntroMatch, MatchCard, NoMoreCard } from '@/components/match';
 import FetchMoreCard from '@/components/match/FetchMoreCard';
 
 export default function Match() {
-    const { matchList, removeMatch, fetchMatchList, setShowStamp } =
+    const { matchList, removeMatch, fetchMatchList, setShowStamp, isLastPage } =
         useMatchStore();
+    const { user } = useUserStore();
     const [isModalOpen, setIsModalOpen] = useState(true);
 
     // 카드 관련 이벤트 핸들러
-    const handleDragEnd = (id: string) => {
-        removeMatch(id);
-        setShowStamp(false);
+    const handleDragEnd = (otherId: number) => {
+        if (user) {
+            removeMatch(user.id, otherId);
+            setShowStamp(false);
+        }
     };
     const handleFetchMore = () => {
-        fetchMatchList();
+        if (user) fetchMatchList(user.id);
     };
     const handleOnClickBtn = () => {
         if (matchList.length > 0) setShowStamp(true);
@@ -29,17 +32,21 @@ export default function Match() {
     };
 
     useEffect(() => {
-        if (!(matchList.length > 0)) fetchMatchList();
+        if (!(matchList.length > 0) && user) fetchMatchList(user.id);
 
         const skip = localStorage.getItem('skipMatchIntro');
         if (skip === 'true') {
             setIsModalOpen(false);
         }
+
+        return () => {
+            useMatchStore.setState({ isLastPage: false });
+        };
     }, []);
 
     return (
         <>
-            <div className="h-screen flex flex-col items-center justify-center gap-[120px] bg-gray-100">
+            <div className="h-screen flex flex-col items-center justify-center bg-gray-100">
                 <div className="relative w-[240px] h-[400px] flex items-center justify-center">
                     <AnimatePresence>
                         {/* 가장 위 카드와 바로 아래 카드만 렌더링 */}
@@ -52,17 +59,17 @@ export default function Match() {
                                 onDragEnd={handleDragEnd}
                             />
                         ))}
-
                         {/* 모든 카드가 사라지면 새로운 데이터를 요청하는 카드 표시 */}
-                        {matchList.length === 0 && (
+                        {isLastPage && <NoMoreCard />}
+                        {matchList.length === 0 && !isLastPage && (
                             <FetchMoreCard onFetchMore={handleFetchMore} />
                         )}
                     </AnimatePresence>
                 </div>
                 <button
-                    className="btn-solid max-w-[240px]"
+                    className={`btn-solid max-w-[240px] ${(matchList.length === 0 || isLastPage) && 'active:scale-100'}`}
                     onClick={handleOnClickBtn}
-                    disabled={!(matchList.length > 0)}
+                    disabled={matchList.length === 0 || isLastPage}
                 >
                     우리 멍멍이 부탁하기
                 </button>

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom';
-import { useMatchStore, useUserStore } from '@/stores';
+import { useMatchStore, useTitleStore, useUserStore } from '@/stores';
 import { AnimatePresence } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import { IntroMatch, MatchCard, NoMoreCard } from '@/components/match';
@@ -9,6 +9,7 @@ export default function Match() {
     const { matchList, removeMatch, fetchMatchList, setShowStamp, isLastPage } =
         useMatchStore();
     const { user } = useUserStore();
+    const { setTitle } = useTitleStore();
     const [isModalOpen, setIsModalOpen] = useState(true);
 
     // 카드 관련 이벤트 핸들러
@@ -38,6 +39,8 @@ export default function Match() {
         if (skip === 'true') {
             setIsModalOpen(false);
         }
+
+        setTitle('돌봄 매칭');
 
         return () => {
             useMatchStore.setState({ isLastPage: false });

--- a/src/stores/useChatStore.ts
+++ b/src/stores/useChatStore.ts
@@ -3,7 +3,7 @@ import {
     createChatRoom,
     getChatMessageList,
     getChatRoomList,
-} from '@/hooks/api/Chat';
+} from '@/hooks/api/chat';
 import { IChatMessage, IChatRoom } from '@/types/chat';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';

--- a/src/stores/useMatchStore.ts
+++ b/src/stores/useMatchStore.ts
@@ -1,79 +1,79 @@
-import { Match } from '@/types/match';
+import { getMatchList, postMatchFail } from '@/hooks/api/match';
+import { IMatch } from '@/types/match';
 import { create } from 'zustand';
 
-export interface MatchWidthColor extends Match {
+export interface MatchWidthColor extends IMatch {
     color?: string;
 }
 
 interface MatchStore {
     matchList: MatchWidthColor[];
     showStamp: boolean;
-    removeMatch: (id: string) => void;
-    fetchMatchList: () => void;
+    removeMatch: (userId: number, otherId: number) => void;
+    fetchMatchList: (userId: number) => void;
     setShowStamp: (state: boolean) => void;
+    curPage: number;
+    totalPages: number;
+    isLastPage: boolean;
 }
 
-const useMatchStore = create<MatchStore>((set) => ({
+const useMatchStore = create<MatchStore>((set, get) => ({
     matchList: [],
     showStamp: false,
+    curPage: 1,
+    totalPages: 1,
+    isLastPage: false,
     setShowStamp: (state) => set(() => ({ showStamp: state })),
-    removeMatch: (id) =>
+    removeMatch: async (userId, otherId) => {
+        const { ok } = await postMatchFail({
+            userId,
+            targetUserId: otherId,
+        });
+
+        if (!ok) return;
+
         set((state) => ({
-            matchList: state.matchList.filter((match) => match.id !== id),
-        })),
-    fetchMatchList: () =>
-        set(() => ({
-            matchList: [
-                {
-                    id: '1',
-                    nickname: '테스트1',
-                    introduction: '애견인입니다.',
-                    recommendationCount: 101,
-                    careCompletionCount: 105,
-                    latitude: 37.55258760777118,
-                    longitude: 126.97441248152484,
-                },
-                {
-                    id: '2',
-                    nickname: '테스트2',
-                    introduction: '애견인입니다.',
-                    recommendationCount: 101,
-                    careCompletionCount: 105,
-                    latitude: 37.55258760777118,
-                    longitude: 126.97441248152484,
-                },
-                {
-                    id: '3',
-                    nickname: '테스트3',
-                    introduction: '애견인입니다.',
-                    recommendationCount: 101,
-                    careCompletionCount: 105,
-                    latitude: 37.55258760777118,
-                    longitude: 126.97441248152484,
-                },
-                {
-                    id: '4',
-                    nickname: '테스트4',
-                    introduction: '애견인입니다.',
-                    recommendationCount: 101,
-                    careCompletionCount: 105,
-                    latitude: 37.55258760777118,
-                    longitude: 126.97441248152484,
-                },
-                {
-                    id: '5',
-                    nickname: '테스트5',
-                    introduction: '애견인입니다.',
-                    recommendationCount: 101,
-                    careCompletionCount: 105,
-                    latitude: 37.55258760777118,
-                    longitude: 126.97441248152484,
-                },
-            ].map((match, idx) => ({
-                ...match,
-                color: idx % 2 === 0 ? 'bg-white' : 'bg-point-50',
-            })),
-        })),
+            matchList: state.matchList.filter(
+                (otherUser) => otherUser.id !== otherId,
+            ),
+        }));
+    },
+    fetchMatchList: async (userId) => {
+        const { curPage, totalPages } = get();
+
+        if (curPage > totalPages) {
+            set(() => ({ isLastPage: true }));
+            return;
+        }
+
+        const { ok, data, error, status } = await getMatchList({
+            userId,
+            page: curPage,
+        });
+
+        if (!ok) {
+            console.error(error?.status, error?.msg);
+            return;
+        }
+
+        if (status === 204) {
+            set(() => ({ isLastPage: true }));
+            return;
+        }
+
+        const { matchResults, totalPages: newTotalPage } = data.result;
+
+        if (matchResults.length > 0) {
+            set((state) => ({
+                matchList: matchResults.map((match, idx) => ({
+                    ...match,
+                    color: idx % 2 === 0 ? 'bg-white' : 'bg-point-50',
+                })),
+                curPage: state.curPage,
+                totalPages: newTotalPage,
+            }));
+        }
+    },
 }));
 
 export default useMatchStore;

--- a/src/types/baseResponse.d.ts
+++ b/src/types/baseResponse.d.ts
@@ -1,5 +1,6 @@
 interface BaseApiResponse {
     ok: boolean;
+    status?: number;
     error?: {
         status: number;
         msg: string;

--- a/src/types/chat.d.ts
+++ b/src/types/chat.d.ts
@@ -19,7 +19,7 @@ interface IChatMessage {
     senderId: string;
     receiverId: string;
     msg: string;
-    msg_type: 'msg' | 'plz' | 'end';
+    msg_type: 'MSG' | 'PLZ' | 'END';
     msgTimestamp: string;
     readStatus: boolean;
 }
@@ -30,7 +30,7 @@ interface ChatRoomCreateApiRequest {
 }
 interface ChatRoomCreateApiResponse extends BaseApiResponse {
     data: {
-        result: string;
+        result: number;
     };
 }
 

--- a/src/types/match.d.ts
+++ b/src/types/match.d.ts
@@ -1,18 +1,37 @@
 import { BaseApiResponse } from './baseResponse';
 
-interface Match {
-    id: string;
+interface IMatch {
+    id: number;
     nickname: string;
-    introduction: string;
     recommendationCount: number;
     careCompletionCount: number;
-    profileImg?: string;
-    latitude: number;
-    longitude: number;
+    profileImg: string;
 }
 
+// GET MatchList
+interface MatchListApiRequest {
+    userId: number;
+    page?: number;
+    size?: number;
+}
 interface MatchListApiResponse extends BaseApiResponse {
-    data: Match[];
+    data: {
+        result: {
+            matchResults: IMatch[];
+            totalPages: number;
+        };
+    };
 }
 
-export type { Match, MatchListApiResponse };
+// POST	MatchFail
+interface MatchFailApiRequest {
+    userId: number;
+    targetUserId: number;
+}
+
+export type {
+    IMatch,
+    MatchListApiRequest,
+    MatchListApiResponse,
+    MatchFailApiRequest,
+};


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 매칭 관련 API 연결 로직 작성.
- 매칭 관련 API Request, Response 타입 작성.
- 로그인 기반 동작으로 작성
- 서버 204 응답에 대한 방안으로 NoMoreCard 컴포넌트 작성
  ( 더 이상 매칭 가능한 돌봄이가 없을 때 REST API에서 해당 코드 반환 )

## 📌 이슈 넘버
- - #88 

## 📝 작업 내용
- 매칭 기능 관련 API 요청 및 응답에 대한 타입 지정 및 fetch 로직을 작성했습니다.
- 로그인 유저 정보를 기반으로 동작하도록 전역 스토어의 action을 작성했습니다.
- 응답 값 중 totalPage를 기반으로 REST Api의 페이지네이션을 활용하도록 로직을 수정했습니다.
- 응답 중 204 Status Code 반환을 확인하고, 성공 응답시에도 Status Code를 사용할 수 있도록 Axios의 Base 및 BaseApiResponse 타입을 소폭 수정하였습니다.

## 😭문제점
- 현재 DB에 매칭되는 정보가 없어서, 204 코드만 반환되고 있어, 더이상 테스트가 불가합니다.
  추후 테스트를 통해 정상 동작을 하는지 확인 후 수정이 필요하면 수정하겠습니다.

## 📸 스크린샷
### 204 응답 시 등장
![no_more_match](https://github.com/user-attachments/assets/1c1c86d9-23d1-4b39-a556-3b8dc678a060)

Closes #88 
