### PR TITLE
[Feat] 사용자 인증 컴포넌트 작성

### DIFF
--- a/src/components/auth/AuthGard.tsx
+++ b/src/components/auth/AuthGard.tsx
@@ -1,0 +1,33 @@
+import { getMyProfileInfo } from '@/hooks/api/profile';
+import { useUserStore } from '@/stores';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface AuthenticationProps {
+    element: React.ReactNode;
+    redirectTo: string;
+}
+
+export default function AuthGuard({ element }: AuthenticationProps) {
+    const { user, setUser } = useUserStore();
+    const navigate = useNavigate();
+
+    const validationAuth = async () => {
+        const { ok, data } = await getMyProfileInfo();
+
+        if (!ok) {
+            navigate('/login');
+        } else {
+            const { id, accountId, nickname, isRegistered, region } = data;
+            setUser({ id, accountId, nickname, isRegistered, region });
+        }
+    };
+
+    useEffect(() => {
+        if (!user) {
+            validationAuth();
+        }
+    }, [user]);
+
+    return element;
+}

--- a/src/components/auth/AuthGard.tsx
+++ b/src/components/auth/AuthGard.tsx
@@ -5,10 +5,13 @@ import { useNavigate } from 'react-router-dom';
 
 interface AuthenticationProps {
     element: React.ReactNode;
-    redirectTo: string;
+    redirectTo?: string;
 }
 
-export default function AuthGuard({ element }: AuthenticationProps) {
+export default function AuthGuard({
+    element,
+    redirectTo,
+}: AuthenticationProps) {
     const { user, setUser } = useUserStore();
     const navigate = useNavigate();
 
@@ -16,7 +19,7 @@ export default function AuthGuard({ element }: AuthenticationProps) {
         const { ok, data } = await getMyProfileInfo();
 
         if (!ok) {
-            navigate('/login');
+            navigate(redirectTo || '/login');
         } else {
             const { id, accountId, nickname, isRegistered, region } = data;
             setUser({ id, accountId, nickname, isRegistered, region });

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export { default as AuthGaurd } from './AuthGard';

--- a/src/hooks/api/profile.ts
+++ b/src/hooks/api/profile.ts
@@ -3,11 +3,19 @@ import { http } from './base';
 
 /**
  * GET	Profile informations
- * 나 또는 다른 사람의 개인 정보를 불러옵니다.
+ * 다른 사용자의 프로필 정보를 불러옵니다.
  */
 export const getProfileInfo = async ({
     userId,
 }: ProfileApiQueryString): Promise<ProfileApiResponse> =>
-    await http.get<ProfileApiResponse>(
-        `/api/auth/get-profile?userId=${userId}`,
+    await http.get<ProfileApiResponse, ProfileApiQueryString>(
+        '/api/auth/get-profile',
+        { userId },
     );
+
+/**
+ * GET	MyProfile	informations
+ * 나의 프로필 정보를 불러옵니다.
+ */
+export const getMyProfileInfo = async (): Promise<ProfileApiResponse> =>
+    await http.get<ProfileApiResponse>('/api/auth/get-myprofile');

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -30,7 +30,7 @@ export default function useLoginForm() {
     });
     const [loading, setLoading] = useState(false);
     const [success, setSuccess] = useState(false);
-    const { user, setUser } = useUserStore();
+    const { setUser } = useUserStore();
     const { showToast, isToastActive } = useCustomToast();
     const navigate = useFadeNavigate();
 
@@ -47,35 +47,14 @@ export default function useLoginForm() {
         await postLogin(data).then((response) => {
             console.log(response);
             if (response.ok) {
-                const {
-                    id,
-                    accountId,
-                    nickname,
-                    loginRole,
-                    loginType,
-                    role,
-                    preferredSize,
-                    gender,
-                    isRegistered,
-                    recommendationCount,
-                    careCompletionCount,
-                    isCareAvailable,
-                    mbti,
-                } = response.data;
+                const { id, accountId, nickname, isRegistered, region } =
+                    response.data;
                 setUser({
                     id,
                     accountId,
                     nickname,
-                    loginRole,
-                    loginType,
-                    role,
-                    preferredSize,
-                    gender,
                     isRegistered,
-                    recommendationCount,
-                    careCompletionCount,
-                    isCareAvailable,
-                    mbti,
+                    region,
                 });
                 setSuccess(true);
                 setTimeout(() => {

--- a/src/types/login.d.ts
+++ b/src/types/login.d.ts
@@ -15,13 +15,14 @@ interface LoginApiResponse extends BaseApiResponse {
         loginRole: string;
         loginType: string;
         role: string;
-        preferredSize: string;
+        preferredSize: ('SMALL' | 'MEDIUM' | 'LARGE')[];
         gender: string;
         isRegistered: boolean;
         recommendationCount: number;
         careCompletionCount: number;
         isCareAvailable: boolean;
         mbti: string;
+        region: string;
     };
 }
 

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -4,16 +4,8 @@ interface IUser {
     id: number;
     accountId: string;
     nickname: string;
-    loginRole: string;
-    loginType: string;
-    role: string;
-    preferredSize: string;
-    gender: string;
     isRegistered: boolean;
-    recommendationCount: number;
-    careCompletionCount: number;
-    isCareAvailable: boolean;
-    mbti: string;
+    region: string;
 }
 
 //	GET profile informations
@@ -29,7 +21,7 @@ interface ProfileApiResponse extends BaseApiResponse {
         nickname: string;
         profileImg: string;
         role: string;
-        preferredSizes: string[];
+        preferredSize: ('SMALL' | 'MEDIUM' | 'LARGE')[];
         gender: string;
         introduction: string;
         isRegistered: boolean;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 로그인, 프로필, 유저 스토어 타입을 소폭 수정했습니다.
  - 로그인, 프로필 관련 API 응답 타입: preferredSize 필드의 타입을 유니온 타입으로 수정
  - 유저 스토어 타입 (Iuser): 필수정보( id, accountId, nickname, isRegistered, region )을 제외한 필드 삭제)
- 프로필 관련 API 호출 로직 수정 및 작성
  -  타 유저 프로필 조회 API의 queryString 부분을 살짝 수정했습니다.
  - 내 프로필 조회 API의 호출 로직을 작성했습니다.
- 사용자 인증 컴포넌트 작성
  - 내 프로필 조회 API를 활용, 쿠키로 저장된 JWT 토큰을 기반으로, 로그인 판정을 받는 AuthGuard 컴포넌트를 작성했습니다.
  - 현재 내 프로필 조회 API가 제대로 동작하지 않는 것 같습니다. ( 포스트 맨으로 호출 시에도 404에러 반환 )
  추후 정상 동작 확인시 Route 단에 적용시키겠습니다.

## 📌 이슈 넘버
- #91 

Closes #91 