### PR TITLE
[Feat] 임시 비밀번호 발급 api 연동

### DIFF
--- a/src/hooks/api/password.ts
+++ b/src/hooks/api/password.ts
@@ -1,0 +1,19 @@
+import {
+    PasswordApiResponse,
+    TemporaryPasswordApiRequest,
+} from '@/types/password';
+import { http } from './base';
+
+/**
+ * POST	Send temporary password
+ * 해당 이메일로 임시 비밀번호를 보냅니다.
+ */
+export const postTemporaryPassword = async ({
+    accountId,
+}: TemporaryPasswordApiRequest): Promise<PasswordApiResponse> =>
+    await http.post<PasswordApiResponse, TemporaryPasswordApiRequest>(
+        '/api/auth/send-repassword',
+        {
+            accountId,
+        },
+    );

--- a/src/hooks/useForgotPasswordForm.ts
+++ b/src/hooks/useForgotPasswordForm.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { postTemporaryPassword } from './api/password';
-import useFadeNavigate from './useFadeNavigate';
+import useCustomToast from './useCustomToast';
 
 /**
  * ForgotPassword form input type
@@ -26,20 +26,26 @@ export default function useForgotPasswordForm() {
     });
     const [success, setSuccess] = useState(false);
     const [loading, setLoading] = useState(false);
-    const navigate = useFadeNavigate();
+    const { showToast, isToastActive } = useCustomToast();
 
     /**
      * Handles form submission
      */
     const onSubmit = async (data: ForgotPasswordInputs) => {
+        if (isToastActive()) {
+            return;
+        }
         setLoading(true);
         const accountId = data.email;
         await postTemporaryPassword({ accountId }).then((response) => {
             if (response.ok) {
                 setSuccess(true);
-                setTimeout(() => {
-                    navigate('/login');
-                }, 3000);
+            } else {
+                if (response.error?.status === 404) {
+                    showToast('존재하지 않는 사용자입니다!', 'warning');
+                } else {
+                    showToast('서버 연결 문제가 발생했습니다!', 'warning');
+                }
             }
         });
         setLoading(false);

--- a/src/hooks/useForgotPasswordForm.ts
+++ b/src/hooks/useForgotPasswordForm.ts
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { postTemporaryPassword } from './api/password';
+import useFadeNavigate from './useFadeNavigate';
 
 /**
  * ForgotPassword form input type
@@ -23,14 +25,21 @@ export default function useForgotPasswordForm() {
         mode: 'onChange',
     });
     const [success, setSuccess] = useState(false);
+    const navigate = useFadeNavigate();
 
     /**
      * Handles form submission
      */
-    const onSubmit = (data: ForgotPasswordInputs) => {
-        console.log(data);
-        // 여기에 로그인 로직을 구현하세요
-        setSuccess(true);
+    const onSubmit = async (data: ForgotPasswordInputs) => {
+        const accountId = data.email;
+        await postTemporaryPassword({ accountId }).then((response) => {
+            if (response.ok) {
+                setSuccess(true);
+                setTimeout(() => {
+                    navigate('/login');
+                }, 3000);
+            }
+        });
     };
 
     /**

--- a/src/hooks/useForgotPasswordForm.ts
+++ b/src/hooks/useForgotPasswordForm.ts
@@ -25,12 +25,14 @@ export default function useForgotPasswordForm() {
         mode: 'onChange',
     });
     const [success, setSuccess] = useState(false);
+    const [loading, setLoading] = useState(false);
     const navigate = useFadeNavigate();
 
     /**
      * Handles form submission
      */
     const onSubmit = async (data: ForgotPasswordInputs) => {
+        setLoading(true);
         const accountId = data.email;
         await postTemporaryPassword({ accountId }).then((response) => {
             if (response.ok) {
@@ -40,6 +42,7 @@ export default function useForgotPasswordForm() {
                 }, 3000);
             }
         });
+        setLoading(false);
     };
 
     /**
@@ -62,5 +65,6 @@ export default function useForgotPasswordForm() {
         onSubmit,
         isValid,
         success,
+        loading,
     };
 }

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -201,6 +201,10 @@ export default function useSignupForm() {
             value: 8,
             message: '비밀번호는 최소 8자 이상이어야 합니다!',
         },
+        maxLength: {
+            value: 20,
+            message: '비밀번호는 최대 20자 이하이어야 합니다!',
+        },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,
             message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다!',

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,7 +1,7 @@
 import { useFadeNavigate, useForgotPasswordForm } from '@/hooks';
 import { useCallback } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
-import { CustomInput, Loading } from '@/components/common';
+import { CustomInput, Loading, ToastAnchor } from '@/components/common';
 import { Success } from '@/components/forgot-password';
 
 export default function ForgotPassword() {
@@ -22,66 +22,67 @@ export default function ForgotPassword() {
         navigate('/login');
     }, []);
 
-    if (loading) {
-        return <Loading />;
-    }
-
     return (
-        <div
-            className={`h-screen ${success ? 'bg-white' : 'bg-gray-100'} flex flex-col justify-between overflow-hidden`}
-        >
-            <header className="bg-white h-14 w-full flex items-center justify-center">
-                <Back
-                    onClick={handleBackBtn}
-                    className="absolute left-[26px] cursor-pointer"
-                />
-                <h1 className="text-point-900 text-body-l font-extrabold">
-                    비밀번호 재발급
-                </h1>
-            </header>
-            {!success ? (
-                <>
-                    <section className="flex-1 flex flex-col justify-start">
-                        <div className="bg-white pt-6 pb-12 flex flex-col">
-                            <div className="w-full max-w-[600px] px-6 mx-auto">
-                                <div className="text-title-s font-extrabold text-gray-800 pb-12">
-                                    <p>임시 비밀번호를</p>
-                                    <p>이메일로 보내드릴게요!</p>
+        <>
+            {loading && <Loading />}
+            <div
+                className={`${loading && 'hidden'} h-screen ${success ? 'bg-white' : 'bg-gray-100'} flex flex-col justify-between overflow-hidden`}
+            >
+                <header className="bg-white h-14 w-full flex items-center justify-center">
+                    <Back
+                        onClick={handleBackBtn}
+                        className="absolute left-[26px] cursor-pointer"
+                    />
+                    <h1 className="text-point-900 text-body-l font-extrabold">
+                        비밀번호 재발급
+                    </h1>
+                </header>
+                {!success ? (
+                    <>
+                        <section className="flex-1 flex flex-col justify-start">
+                            <div className="bg-white pt-6 pb-12 flex flex-col">
+                                <div className="w-full max-w-[600px] px-6 mx-auto">
+                                    <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                                        <p>임시 비밀번호를</p>
+                                        <p>이메일로 보내드릴게요!</p>
+                                    </div>
+                                    <form
+                                        id="forgot-form"
+                                        onSubmit={handleSubmit(onSubmit)}
+                                    >
+                                        <CustomInput
+                                            id="email"
+                                            label="이메일"
+                                            type="text"
+                                            placeholder="이메일을 입력해주세요."
+                                            register={register}
+                                            watch={watch}
+                                            validation={emailValidation}
+                                            error={errors.email?.message}
+                                            design="outline"
+                                            successMsg="좋아요!"
+                                        />
+                                    </form>
                                 </div>
-                                <form
-                                    id="forgot-form"
-                                    onSubmit={handleSubmit(onSubmit)}
-                                >
-                                    <CustomInput
-                                        id="email"
-                                        label="이메일"
-                                        type="text"
-                                        placeholder="이메일을 입력해주세요."
-                                        register={register}
-                                        watch={watch}
-                                        validation={emailValidation}
-                                        error={errors.email?.message}
-                                        design="outline"
-                                        successMsg="좋아요!"
-                                    />
-                                </form>
                             </div>
-                        </div>
-                    </section>
-                    <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto">
-                        <button
-                            type="submit"
-                            form="forgot-form"
-                            className="btn-solid"
-                            disabled={!isValid || !!errors.email}
-                        >
-                            확인
-                        </button>
-                    </footer>
-                </>
-            ) : (
-                <Success />
-            )}
-        </div>
+                        </section>
+                        <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto">
+                            <ToastAnchor>
+                                <button
+                                    type="submit"
+                                    form="forgot-form"
+                                    className="btn-solid"
+                                    disabled={!isValid || !!errors.email}
+                                >
+                                    확인
+                                </button>
+                            </ToastAnchor>
+                        </footer>
+                    </>
+                ) : (
+                    <Success />
+                )}
+            </div>
+        </>
     );
 }

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,7 +1,7 @@
 import { useFadeNavigate, useForgotPasswordForm } from '@/hooks';
 import { useCallback } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
-import { CustomInput } from '@/components/common';
+import { CustomInput, Loading } from '@/components/common';
 import { Success } from '@/components/forgot-password';
 
 export default function ForgotPassword() {
@@ -15,11 +15,16 @@ export default function ForgotPassword() {
         onSubmit,
         isValid,
         success,
+        loading,
     } = useForgotPasswordForm();
 
     const handleBackBtn = useCallback(() => {
         navigate('/login');
     }, []);
+
+    if (loading) {
+        return <Loading />;
+    }
 
     return (
         <div

--- a/src/types/password.d.ts
+++ b/src/types/password.d.ts
@@ -1,0 +1,14 @@
+import { BaseApiResponse } from './baseResponse';
+
+//	POST temporary password
+interface TemporaryPasswordApiRequest {
+    accountId: string;
+}
+interface PasswordApiResponse extends BaseApiResponse {
+    data: {
+        responseCode: string;
+        message: string;
+    };
+}
+
+export type { TemporaryPasswordApiRequest, PasswordApiResponse };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

임시 비밀번호 발급 페이지 컴포넌트 api 연동

## 📌 이슈 넘버

- #113 

## 📝 작업 내용

- 임시 비밀번호 발급 api 요청, 응답 타입 정의
- 임시 비밀번호 발급 api 요청 함수 정의
- useForgotPasswordFrom.ts 코드 추가
- 페이지 컴포넌트 로딩 추가
- api 에러 처리

## 📸 스크린샷(선택)

![forgotpw](https://github.com/user-attachments/assets/eb605afa-2f40-4e8e-b949-1c574058caf4)
