### PR TITLE
[Feat] 비밀번호 변경 api 연동

### DIFF
--- a/src/components/change-password/Success.tsx
+++ b/src/components/change-password/Success.tsx
@@ -7,7 +7,7 @@ export default function Success() {
     const navigate = useFadeNavigate();
 
     const handleCheckBtn = useCallback(() => {
-        navigate('/profile');
+        navigate(-1);
     }, []);
 
     return (

--- a/src/hooks/api/password.ts
+++ b/src/hooks/api/password.ts
@@ -1,4 +1,5 @@
 import {
+    NewPasswordApiRequest,
     PasswordApiResponse,
     TemporaryPasswordApiRequest,
 } from '@/types/password';
@@ -15,5 +16,21 @@ export const postTemporaryPassword = async ({
         '/api/auth/send-repassword',
         {
             accountId,
+        },
+    );
+
+/**
+ * POST	Send new password
+ * 비밀번호를 변경합니다.
+ */
+export const postNewPassword = async ({
+    currentPassword,
+    newPassword,
+}: NewPasswordApiRequest): Promise<PasswordApiResponse> =>
+    await http.post<PasswordApiResponse, NewPasswordApiRequest>(
+        '/api/auth/repassword',
+        {
+            currentPassword,
+            newPassword,
         },
     );

--- a/src/hooks/useChangePasswordForm.ts
+++ b/src/hooks/useChangePasswordForm.ts
@@ -1,5 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
+import { postNewPassword } from './api/password';
 
 /**
  * ChangePassword form input type
@@ -31,10 +32,15 @@ export default function useChangePasswordForm() {
     /**
      * Handles form submission
      */
-    const onSubmit = (data: ChangePasswordInputs) => {
-        console.log(data);
-        // 여기에 로직을 구현하세요
-        setSuccess(true);
+    const onSubmit = async (data: ChangePasswordInputs) => {
+        const { currentPassword, newPassword } = data;
+        await postNewPassword({ currentPassword, newPassword }).then(
+            (response) => {
+                if (response.ok) {
+                    setSuccess(true);
+                }
+            },
+        );
     };
 
     /**

--- a/src/hooks/useChangePasswordForm.ts
+++ b/src/hooks/useChangePasswordForm.ts
@@ -1,6 +1,7 @@
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { postNewPassword } from './api/password';
+import { useCustomToast } from '@/components/common';
 
 /**
  * ChangePassword form input type
@@ -29,17 +30,27 @@ export default function useChangePasswordForm() {
     });
     const [success, setSuccess] = useState(false);
     const [loading, setLoading] = useState(false);
+    const { showToast, isToastActive } = useCustomToast();
 
     /**
      * Handles form submission
      */
     const onSubmit = async (data: ChangePasswordInputs) => {
+        if (isToastActive()) {
+            return;
+        }
         setLoading(true);
         const { currentPassword, newPassword } = data;
         await postNewPassword({ currentPassword, newPassword }).then(
             (response) => {
                 if (response.ok) {
                     setSuccess(true);
+                } else {
+                    if (response.error?.status === 403) {
+                        showToast('틀린 비밀번호입니다!', 'warning');
+                    } else {
+                        showToast('서버 연결 문제가 발생했습니다!', 'warning');
+                    }
                 }
             },
         );

--- a/src/hooks/useChangePasswordForm.ts
+++ b/src/hooks/useChangePasswordForm.ts
@@ -66,6 +66,10 @@ export default function useChangePasswordForm() {
             value: 8,
             message: '비밀번호는 최소 8자 이상이어야 합니다!',
         },
+        maxLength: {
+            value: 20,
+            message: '비밀번호는 최대 20자 이하이어야 합니다!',
+        },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,
             message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다!',
@@ -80,6 +84,10 @@ export default function useChangePasswordForm() {
         minLength: {
             value: 8,
             message: '비밀번호는 최소 8자 이상이어야 합니다!',
+        },
+        maxLength: {
+            value: 20,
+            message: '비밀번호는 최대 20자 이하이어야 합니다!',
         },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,

--- a/src/hooks/useChangePasswordForm.ts
+++ b/src/hooks/useChangePasswordForm.ts
@@ -28,11 +28,13 @@ export default function useChangePasswordForm() {
         mode: 'onChange',
     });
     const [success, setSuccess] = useState(false);
+    const [loading, setLoading] = useState(false);
 
     /**
      * Handles form submission
      */
     const onSubmit = async (data: ChangePasswordInputs) => {
+        setLoading(true);
         const { currentPassword, newPassword } = data;
         await postNewPassword({ currentPassword, newPassword }).then(
             (response) => {
@@ -41,6 +43,7 @@ export default function useChangePasswordForm() {
                 }
             },
         );
+        setLoading(false);
     };
 
     /**
@@ -97,5 +100,6 @@ export default function useChangePasswordForm() {
         onSubmit,
         isValid,
         success,
+        loading,
     };
 }

--- a/src/hooks/useForgotPasswordForm.ts
+++ b/src/hooks/useForgotPasswordForm.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { postTemporaryPassword } from './api/password';
-import useCustomToast from './useCustomToast';
+import { useCustomToast } from '@/components/common';
 
 /**
  * ForgotPassword form input type

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -93,6 +93,10 @@ export default function useLoginForm() {
             value: 8,
             message: '비밀번호는 최소 8자 이상이어야 합니다!',
         },
+        maxLength: {
+            value: 20,
+            message: '비밀번호는 최대 20자 이하이어야 합니다!',
+        },
         pattern: {
             value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/,
             message: '비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다!',

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import useFadeNavigate from './useFadeNavigate';
 import { postSignup } from './api/signup';
-import useCustomToast from './useCustomToast';
+import { useCustomToast } from '@/components/common';
 
 /**
  * Signup form types

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -2,7 +2,7 @@ import { useChangePasswordForm, useFadeNavigate } from '@/hooks';
 import { useCallback, useState } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
 import Eye from '@/assets/images/change-password/eye.svg?react';
-import { CustomInput } from '@/components/common';
+import { CustomInput, Loading } from '@/components/common';
 import { Success } from '@/components/change-password';
 
 export default function ChangePassword() {
@@ -18,6 +18,7 @@ export default function ChangePassword() {
         onSubmit,
         isValid,
         success,
+        loading,
     } = useChangePasswordForm();
     const [show, setShow] = useState(false);
 
@@ -30,100 +31,120 @@ export default function ChangePassword() {
     }, []);
 
     return (
-        <div
-            className={`h-screen ${success ? 'bg-white' : 'bg-gray-100'} flex flex-col justify-between overflow-hidden`}
-        >
-            <header className="bg-white h-14 w-full flex items-center justify-center">
-                <Back
-                    onClick={handleBackBtn}
-                    className="absolute left-[26px] cursor-pointer"
-                />
-                <h1 className="text-point-900 text-body-l font-extrabold">
-                    비밀번호 변경
-                </h1>
-            </header>
-            {!success ? (
-                <>
-                    <section className="flex-1 flex flex-col justify-start">
-                        <div className="bg-white pt-6 pb-12 flex flex-col">
-                            <div className="w-full max-w-[600px] px-6 mx-auto">
-                                <div className="text-title-s font-extrabold text-gray-800 pb-12">
-                                    <p>새로운 비밀번호를</p>
-                                    <p>입력해주세요!</p>
-                                </div>
-                                <form
-                                    id="change-form"
-                                    onSubmit={handleSubmit(onSubmit)}
-                                    className="flex flex-col gap-1"
-                                >
-                                    <CustomInput
-                                        id="currentPassword"
-                                        label="현재 비밀번호"
-                                        type="text"
-                                        placeholder="현재 비밀번호를 입력해주세요."
-                                        register={register}
-                                        watch={watch}
-                                        validation={currentPasswordValidation}
-                                        error={errors.currentPassword?.message}
-                                        design="outline"
-                                        successMsg="좋아요!"
-                                    />
-                                    <div className="relative">
+        <>
+            {loading && <Loading />}
+            <div
+                className={`${loading && 'hidden'} h-screen ${success ? 'bg-white' : 'bg-gray-100'} flex flex-col justify-between overflow-hidden`}
+            >
+                <header className="bg-white h-14 w-full flex items-center justify-center">
+                    <Back
+                        onClick={handleBackBtn}
+                        className="absolute left-[26px] cursor-pointer"
+                    />
+                    <h1 className="text-point-900 text-body-l font-extrabold">
+                        비밀번호 변경
+                    </h1>
+                </header>
+                {!success ? (
+                    <>
+                        <section className="flex-1 flex flex-col justify-start">
+                            <div className="bg-white pt-6 pb-12 flex flex-col">
+                                <div className="w-full max-w-[600px] px-6 mx-auto">
+                                    <div className="text-title-s font-extrabold text-gray-800 pb-12">
+                                        <p>새로운 비밀번호를</p>
+                                        <p>입력해주세요!</p>
+                                    </div>
+                                    <form
+                                        id="change-form"
+                                        onSubmit={handleSubmit(onSubmit)}
+                                        className="flex flex-col gap-1"
+                                    >
                                         <CustomInput
-                                            id="newPassword"
-                                            label="새로운 비밀번호"
-                                            type={show ? 'text' : 'password'}
-                                            placeholder="새로운 비밀번호를 입력해주세요."
+                                            id="currentPassword"
+                                            label="현재 비밀번호"
+                                            type="text"
+                                            placeholder="현재 비밀번호를 입력해주세요."
                                             register={register}
                                             watch={watch}
-                                            validation={newPasswordValidation}
-                                            error={errors.newPassword?.message}
+                                            validation={
+                                                currentPasswordValidation
+                                            }
+                                            error={
+                                                errors.currentPassword?.message
+                                            }
                                             design="outline"
                                             successMsg="좋아요!"
                                         />
-                                        <Eye
-                                            onClick={handlePasswordShowBtn}
-                                            className={`absolute bottom-8 right-6 ${show ? 'text-point-500' : 'text-point-200'} cursor-pointer`}
+                                        <div className="relative">
+                                            <CustomInput
+                                                id="newPassword"
+                                                label="새로운 비밀번호"
+                                                type={
+                                                    show ? 'text' : 'password'
+                                                }
+                                                placeholder="새로운 비밀번호를 입력해주세요."
+                                                register={register}
+                                                watch={watch}
+                                                validation={
+                                                    newPasswordValidation
+                                                }
+                                                error={
+                                                    errors.newPassword?.message
+                                                }
+                                                design="outline"
+                                                successMsg="좋아요!"
+                                            />
+                                            <Eye
+                                                onClick={handlePasswordShowBtn}
+                                                className={`absolute bottom-8 right-6 ${show ? 'text-point-500' : 'text-point-200'} cursor-pointer`}
+                                            />
+                                        </div>
+                                        <CustomInput
+                                            id="confirmPassword"
+                                            label="새로운 비밀번호 확인"
+                                            type="password"
+                                            placeholder="비밀번호를 확인해주세요."
+                                            register={register}
+                                            watch={watch}
+                                            validation={
+                                                confirmPasswordValidation
+                                            }
+                                            error={
+                                                errors.confirmPassword?.message
+                                            }
+                                            design="outline"
+                                            successMsg="좋아요!"
                                         />
-                                    </div>
-                                    <CustomInput
-                                        id="confirmPassword"
-                                        label="새로운 비밀번호 확인"
-                                        type="password"
-                                        placeholder="비밀번호를 확인해주세요."
-                                        register={register}
-                                        watch={watch}
-                                        validation={confirmPasswordValidation}
-                                        error={errors.confirmPassword?.message}
-                                        design="outline"
-                                        successMsg="좋아요!"
-                                    />
-                                </form>
+                                    </form>
+                                </div>
                             </div>
-                        </div>
-                    </section>
-                    <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto flex flex-col gap-[10px]">
-                        <button onClick={handleBackBtn} className="btn-outline">
-                            돌아가기
-                        </button>
-                        <button
-                            type="submit"
-                            form="change-form"
-                            className="btn-solid"
-                            disabled={
-                                !isValid ||
-                                !!errors.currentPassword ||
-                                !!errors.newPassword ||
-                                !!errors.confirmPassword
-                            }
-                        >
-                            변경하기
-                        </button>
-                    </footer>
-                </>
-            ) : (
-                <Success />
-            )}
-        </div>
+                        </section>
+                        <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto flex flex-col gap-[10px]">
+                            <button
+                                onClick={handleBackBtn}
+                                className="btn-outline"
+                            >
+                                돌아가기
+                            </button>
+                            <button
+                                type="submit"
+                                form="change-form"
+                                className="btn-solid"
+                                disabled={
+                                    !isValid ||
+                                    !!errors.currentPassword ||
+                                    !!errors.newPassword ||
+                                    !!errors.confirmPassword
+                                }
+                            >
+                                변경하기
+                            </button>
+                        </footer>
+                    </>
+                ) : (
+                    <Success />
+                )}
+            </div>
+        </>
     );
 }

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -2,7 +2,7 @@ import { useChangePasswordForm, useFadeNavigate } from '@/hooks';
 import { useCallback, useState } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
 import Eye from '@/assets/images/change-password/eye.svg?react';
-import { CustomInput, Loading } from '@/components/common';
+import { CustomInput, Loading, ToastAnchor } from '@/components/common';
 import { Success } from '@/components/change-password';
 
 export default function ChangePassword() {
@@ -126,19 +126,21 @@ export default function ChangePassword() {
                             >
                                 돌아가기
                             </button>
-                            <button
-                                type="submit"
-                                form="change-form"
-                                className="btn-solid"
-                                disabled={
-                                    !isValid ||
-                                    !!errors.currentPassword ||
-                                    !!errors.newPassword ||
-                                    !!errors.confirmPassword
-                                }
-                            >
-                                변경하기
-                            </button>
+                            <ToastAnchor>
+                                <button
+                                    type="submit"
+                                    form="change-form"
+                                    className="btn-solid"
+                                    disabled={
+                                        !isValid ||
+                                        !!errors.currentPassword ||
+                                        !!errors.newPassword ||
+                                        !!errors.confirmPassword
+                                    }
+                                >
+                                    변경하기
+                                </button>
+                            </ToastAnchor>
                         </footer>
                     </>
                 ) : (

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -54,11 +54,11 @@ export default function AppRoutes() {
                         path="/forgot-password"
                         element={<ForgotPassword />}
                     />
-                    <Route
-                        path="/change-password"
-                        element={<ChangePassword />}
-                    />
                     <Route element={<AuthGaurd />}>
+                        <Route
+                            path="/change-password"
+                            element={<ChangePassword />}
+                        />
                         <Route
                             path="/delete-account"
                             element={<DeleteAccount />}

--- a/src/types/password.d.ts
+++ b/src/types/password.d.ts
@@ -4,6 +4,11 @@ import { BaseApiResponse } from './baseResponse';
 interface TemporaryPasswordApiRequest {
     accountId: string;
 }
+//	POST new password
+interface NewPasswordApiRequest {
+    currentPassword: string;
+    newPassword: string;
+}
 interface PasswordApiResponse extends BaseApiResponse {
     data: {
         responseCode: string;
@@ -11,4 +16,8 @@ interface PasswordApiResponse extends BaseApiResponse {
     };
 }
 
-export type { TemporaryPasswordApiRequest, PasswordApiResponse };
+export type {
+    TemporaryPasswordApiRequest,
+    NewPasswordApiRequest,
+    PasswordApiResponse,
+};


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

비밀번호 변경 페이지 컴포넌트에 api 연동

## 📌 이슈 넘버

- #115 

## 📝 작업 내용

- router.ts 라우트 수정
- 비밀번호 변경 api 요청, 응답 타입 정의
- 비밀번호 변경 api 요청 함수 정의
- useChangePasswordForm.ts에 함수 사용
- 비밀번호 변경 api 로딩 처리
- 비밀번호 변경 api 응답 처리
- 비밀번호 변경 완료 페이지 버튼 navigate 수정
- 모든 비밀번호 react-hook-form validation 통일

## 📸 스크린샷(선택)

![changepw](https://github.com/user-attachments/assets/652920bd-7028-4d83-8759-fbdcd758f878)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
