### PR TITLE
[Feat] s3 이미지 업로드 함수 작성

### DIFF
--- a/src/hooks/api/base.ts
+++ b/src/hooks/api/base.ts
@@ -6,8 +6,21 @@ const service = axios.create({
     timeout: 5000,
 });
 
+const serviceForImage = axios.create({
+    baseURL: ``,
+    withCredentials: true,
+    timeout: 5000,
+});
+
 // 응답 인터셉터 설정
 service.interceptors.response.use(
+    (res: AxiosResponse) => res, // 정상 응답 반환
+    (error) => {
+        // 에러를 일반 객체로 변환하지 않고 그대로 반환
+        return Promise.reject(error);
+    },
+);
+serviceForImage.interceptors.response.use(
     (res: AxiosResponse) => res, // 정상 응답 반환
     (error) => {
         // 에러를 일반 객체로 변환하지 않고 그대로 반환
@@ -115,6 +128,33 @@ export const http = {
     ): Promise<T> {
         try {
             const response = await service.patch<T>(url, data);
+            return {
+                ok: true,
+                status: response.status,
+                data: response.data,
+            } as T;
+        } catch (error: any) {
+            return {
+                ok: false,
+                error: {
+                    status: error.response?.status || 500,
+                    msg:
+                        error.response?.data?.message ||
+                        error.message ||
+                        'Unknown error occurred',
+                },
+            } as T;
+        }
+    },
+};
+
+export const httpForImage = {
+    put: async function put<T, D = undefined>(
+        url: string,
+        data?: D,
+    ): Promise<T> {
+        try {
+            const response = await serviceForImage.put<T>(url, data);
             return {
                 ok: true,
                 status: response.status,

--- a/src/hooks/api/imageUpload.ts
+++ b/src/hooks/api/imageUpload.ts
@@ -22,11 +22,13 @@ export const putImageToS3 = async ({
 }: ImageToS3Params): Promise<boolean> => {
     await httpForImage
         .put<BaseApiResponse, ImageToS3ApiRequest>(imgURL, { img })
-        .then((response) => {
+        .then(async (response) => {
             if (response.ok) {
                 return true;
             } else {
-                // 업로드 실패의 경우
+                const UUID = id;
+                const ImgType = type;
+                await deleteImageUploadError({ UUID, ImgType });
                 return false;
             }
         });

--- a/src/hooks/api/imageUpload.ts
+++ b/src/hooks/api/imageUpload.ts
@@ -1,0 +1,28 @@
+import { ImageToS3ApiRequest, ImageToS3Params } from '@/types/imageUpload';
+import { httpForImage } from './base';
+import { BaseApiResponse } from '@/types/baseResponse';
+
+/**
+ * PUT	S3 이미지 업로드 및 실패 처리
+ * props로 받은 presigned url로 s3 이미지 업로드를 수행하고,
+ * 업로드 실패시에 백엔드로 실패를 알리는 api 요청을 자동 수행
+ * s3 업로드에 성공하면 최종적으로 함수는 true를 반환
+ * s3 업로드에 실패하면 최종적으로 함수는 false를 반환
+ */
+export const putImageToS3 = async ({
+    id,
+    imgURL,
+    img,
+}: ImageToS3Params): Promise<boolean> => {
+    await httpForImage
+        .put<BaseApiResponse, ImageToS3ApiRequest>(imgURL, { img })
+        .then((response) => {
+            if (response.ok) {
+                return true;
+            } else {
+                // 업로드 실패의 경우
+                return false;
+            }
+        });
+    return false;
+};

--- a/src/hooks/api/imageUpload.ts
+++ b/src/hooks/api/imageUpload.ts
@@ -1,5 +1,10 @@
-import { ImageToS3ApiRequest, ImageToS3Params } from '@/types/imageUpload';
-import { httpForImage } from './base';
+import {
+    ImageToS3ApiRequest,
+    ImageToS3Params,
+    ImageUploadErrorApiRequest,
+    ImageUploadErrorApiResponse,
+} from '@/types/imageUpload';
+import { http, httpForImage } from './base';
 import { BaseApiResponse } from '@/types/baseResponse';
 
 /**
@@ -13,6 +18,7 @@ export const putImageToS3 = async ({
     id,
     imgURL,
     img,
+    type,
 }: ImageToS3Params): Promise<boolean> => {
     await httpForImage
         .put<BaseApiResponse, ImageToS3ApiRequest>(imgURL, { img })
@@ -26,3 +32,19 @@ export const putImageToS3 = async ({
         });
     return false;
 };
+
+/**
+ * DELETE	Failed to upload image on s3
+ * s3 이미지 업로드 실패를 백엔드 서버에 알립니다.
+ */
+const deleteImageUploadError = async ({
+    UUID,
+    ImgType,
+}: ImageUploadErrorApiRequest): Promise<ImageUploadErrorApiResponse> =>
+    await http.delete<ImageUploadErrorApiResponse, ImageUploadErrorApiRequest>(
+        '/api/v1/image/error',
+        {
+            UUID,
+            ImgType,
+        },
+    );

--- a/src/types/imageUpload.d.ts
+++ b/src/types/imageUpload.d.ts
@@ -1,0 +1,10 @@
+//	PUT s3 image upload function
+interface ImageToS3ApiRequest {
+    img: FormData;
+}
+interface ImageToS3Params extends ImageToS3ApiRequest {
+    id: number;
+    imgURL: string;
+}
+
+export type { ImageToS3Params, ImageToS3ApiRequest };

--- a/src/types/imageUpload.d.ts
+++ b/src/types/imageUpload.d.ts
@@ -5,6 +5,23 @@ interface ImageToS3ApiRequest {
 interface ImageToS3Params extends ImageToS3ApiRequest {
     id: number;
     imgURL: string;
+    type: 'P' | 'H' | 'U';
 }
 
-export type { ImageToS3Params, ImageToS3ApiRequest };
+//	Delete Failed to upload image on s3
+interface ImageUploadErrorApiRequest {
+    UUID: number;
+    ImgType: 'P' | 'H' | 'U';
+}
+interface ImageUploadErrorApiResponse extends BaseApiResponse {
+    data: {
+        ok: string;
+    };
+}
+
+export type {
+    ImageToS3Params,
+    ImageToS3ApiRequest,
+    ImageUploadErrorApiRequest,
+    ImageUploadErrorApiResponse,
+};


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

이미지 등록이 필요한 api로부터 id값과 presigned url을 받아서
s3 이미지 업로드와 실패시 업로드 실패 api 요청을 자동 처리하는 함수

## 📌 이슈 넘버

- #137 

## 📝 작업 내용

- s3 이미지 업로드 put 요청 api 적용
- 이미지 업로드 실패 요청 api 적용
- 함수 테스트
- 사용법 작성

## 📄사용법

```javascript
const id = 36;  // 이전 api로부터 받은 대상 정보의 uuid
const imgURL = "https://~~~";  // 이전 api로부터 받은 s3 업로드 url
const img = new FormData();
img.append('file', imageFile);  // 무조건 키값은 file 이여야 합니다!!
const type = "U";  // 사용자 프로필에 대한 이미지면 "U"

const result = await putImageToS3(id, imgURL, img, type);

// 함수 내부에서 따로 실패를 백엔드에 보고하는 api가 내재되어 있습니다.
// result boolean 값으로 프론트엔드 화면에 성공 또는 실패 처리하시면 됩니다.
if(result) {
    // 성공
} else {
    // 실패
}
```

|파라미터|타입|설명|
|------|---|---|
|id|number|이전 api로부터 받은 uuid|
|imgURL|string|이전 api로부터 받은 presigned url|
|img|formData|업로드할 이미지가 담긴 formData|
|type|string|"H": 히스토리, "U": 사용자, "P": 동물 (해당 이미지가 사람인지 동물인지 기록 이미지인지 판별)|
