### PR TITLE
[Feat] 공통 이미지 선택 컴포넌트 파일 저장 로직 추가

### DIFF
--- a/src/components/common/ImageSelectBox.tsx
+++ b/src/components/common/ImageSelectBox.tsx
@@ -9,6 +9,7 @@ interface ImageSelectBoxProps {
     imgName: string; // state value of image name
     setImgName: React.Dispatch<React.SetStateAction<string>>; // setState about image name
     className?: string;
+    setImg: React.Dispatch<React.SetStateAction<File | null>>; // setState about image file
 }
 
 export default function ImageSelectBox({
@@ -17,6 +18,7 @@ export default function ImageSelectBox({
     imgName,
     setImgName,
     className = '',
+    setImg,
 }: ImageSelectBoxProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [chosenImgName, setChosenImgName] = useState(imgName);
@@ -45,12 +47,8 @@ export default function ImageSelectBox({
     const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (file) {
-            const reader = new FileReader();
-            reader.onload = (e: ProgressEvent<FileReader>) => {
-                const result = e.target?.result as string; // 타입 단언 사용
-                setChosenImgName(result);
-            };
-            reader.readAsDataURL(file);
+            setImg(file);
+            setChosenImgName(URL.createObjectURL(file));
         }
     };
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

개인 이미지 선택시 s3에 전달할 이미지 파일을 저장할 상태 변수 연동

## 📌 이슈 넘버

- #141 

## 📝 작업 내용

- 개인 이미지 선택시 s3에 전달할 이미지 파일을 저장할 상태 변수 props 추가
- 공통 컴포넌트 로직 수정

## 📄 사용법(업데이트)

```typescript
import { ImageSelectBox } from '../common';
import { useState } from 'react';

export default function Test() {
    const [imgName, setImgName] = useState("profile1");
    const [imgFile, setImg] = useState<File | null>(null);  // 새롭게 추가된 부분 : 이미지 파일이 들어감. s3에 보낼 이미지 파일

    return (
        <div>
             <ImageSelectBox
                 label="프로필 사진"
                 bottomSheetLabel="프로필 이미지를 선택하세요."
                 imgName={imgName}
                 setImgName={setImgName}
                 setImg={setImg}  // 새롭게 추가된 부분
              />
        </div>
    )
}
```
