### PR TITLE
[Feat] 동물등록시 s3 이미지 업로드 로직 적용

### DIFF
--- a/src/components/register/RegisterComplete.tsx
+++ b/src/components/register/RegisterComplete.tsx
@@ -4,6 +4,12 @@ import SmallDog from '@/assets/images/register/registerDog1.svg?react';
 import MiddleDog from '@/assets/images/register/registerDog2.svg?react';
 import LargeDog from '@/assets/images/register/registerDog3.svg?react';
 
+// 종성 존재 여부 확인 함수
+const hasEndConsonant = (str: string) => {
+    const lastChar = str.charAt(str.length - 1);
+    return (lastChar.charCodeAt(0) - 0xac00) % 28 > 0;
+};
+
 export default function RegisterComplete({ getValue }: RegisterCompleteProps) {
     const navigate = useFadeNavigate();
 
@@ -11,6 +17,9 @@ export default function RegisterComplete({ getValue }: RegisterCompleteProps) {
         navigate('/register', { replace: true }); // 새 등록 페이지로 이동
         window.location.reload(); // 상태 초기화
     };
+
+    // 조사 결정
+    const particle = hasEndConsonant(getValue().petName) ? '이는' : '는';
 
     return (
         <div className="flex flex-col justify-between h-screen text-center w-full">
@@ -26,7 +35,7 @@ export default function RegisterComplete({ getValue }: RegisterCompleteProps) {
                 </p>
                 <h2 className="text-body-xl font-extrabold mb-4">
                     <span className="text-point-500">{getValue().petName}</span>
-                    는{' '}
+                    {particle}{' '}
                     <span className="text-point-500">
                         {getValue().temperament}
                     </span>

--- a/src/components/register/RegisterStep2.tsx
+++ b/src/components/register/RegisterStep2.tsx
@@ -9,6 +9,7 @@ export default function RegisterStep2({
     setValue,
     imgName,
     setImgName,
+    setImg,
 }: RegisterStep2Props) {
     const handleNext = () => {
         setValue('profileImg', imgName);
@@ -39,6 +40,7 @@ export default function RegisterStep2({
                                 bottomSheetLabel="프로필 이미지를 선택하세요."
                                 imgName={imgName}
                                 setImgName={setImgName}
+                                setImg={setImg}
                             />
                         </div>
 

--- a/src/hooks/api/register.ts
+++ b/src/hooks/api/register.ts
@@ -7,6 +7,7 @@ import {
     DogRegistrationResponse,
 } from '@/types/register';
 import { useCustomToast } from '@/hooks';
+import { putImageToS3 } from './auth';
 
 // 동물 등록번호 조회 api 호출
 export function useAnimalRegistration() {
@@ -52,18 +53,82 @@ export function useDogRegistration() {
 
     const registerDog = async (
         formData: DogRegistrationRequest,
+        imgFile: File | null,
+        userId: number,
     ): Promise<DogRegistrationResponse | null> => {
-        const response = await http.post<
-            DogRegistrationResponse,
-            DogRegistrationRequest
-        >('/api/pets/register', formData);
+        console.log('imgFile :', imgFile);
 
-        if (response.ok) {
-            showToast('반려견 등록이 완료되었습니다.', 'success');
-            return response;
+        // 기본이미지일때(profile1~3), imgFile이 null로 온다.
+        // 요청 보내기 전에, 이미지가 기본 프로필인 경우는 s3업로드를 skip하고 종료한다.
+        if (formData.profileImg.startsWith('profile')) {
+            const response = await http.post<
+                DogRegistrationResponse,
+                DogRegistrationRequest
+            >('/api/pets/register', formData);
+
+            if (response.ok) {
+                showToast('반려견 등록이 완료되었습니다.', 'success');
+                return response;
+            } else {
+                showToast(
+                    response.error?.msg || '등록에 실패했습니다.',
+                    'warning',
+                );
+                return null;
+            }
         } else {
-            showToast(response.error?.msg || '등록에 실패했습니다.', 'warning');
-            return null;
+            // 사용자가 넣은 사진일 경우, s3업로드를 진행한다.
+            formData.profileImg = '';
+            const response = await http.post<
+                DogRegistrationResponse,
+                DogRegistrationRequest
+            >('/api/pets/register', formData);
+
+            const id = response.data.result.UUID;
+
+            if (response.ok) {
+                // 사용자가 넣은 사진일경우, s3에 이미지 업로드
+                const img = imgFile!;
+
+                const result = await putImageToS3({
+                    id: Number(id),
+                    imgURL: response.data.result.resultImgURL, // presigned URL, 기본이미지일때는 ""로 옴.
+                    img,
+                    type: 'P', // 예: 'PROFILE' 등 적절한 타입 지정
+                });
+                if (result) {
+                    const updatedFormData = {
+                        ...formData,
+                        profileImg: response.data.result.resultImgURL, // S3 이미지 URL로 대체
+                        id: userId,
+                    };
+                    // put 요청 보내기
+                    const response2 = await http.put<
+                        DogRegistrationResponse,
+                        DogRegistrationRequest
+                    >(`/api/pets/${id}`, updatedFormData);
+
+                    if (response2.ok) {
+                        showToast('반려견 등록이 완료되었습니다.', 'success');
+                        return response2;
+                    } else {
+                        showToast(
+                            response2.error?.msg || '등록에 실패했습니다.',
+                            'warning',
+                        );
+                        return null;
+                    }
+                } else {
+                    showToast('이미지 s3 업로드에 실패했습니다.', 'warning');
+                    return null;
+                }
+            } else {
+                showToast(
+                    response.error?.msg || '등록에 실패했습니다.',
+                    'warning',
+                );
+                return null;
+            }
         }
     };
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -11,13 +11,16 @@ import { RegisterStep4 } from '@/components/register';
 import { RegisterComplete } from '@/components/register';
 import { RegisterFormData } from '@/types/register';
 import { useDogRegistration } from '@/hooks/api/register';
+import { useUserStore } from '@/stores';
 
 // 폼 데이터 타입 정의
 export default function Register() {
     const navigate = useFadeNavigate();
     const [step, setStep] = useState(1);
     const [imgName, setImgName] = useState('profile1');
+    const [img, setImg] = useState<File | null>(null); // 새롭게 추가된 부분 : 이미지 파일이 들어감. s3에 보낼 이미지 파일
     const { registerDog } = useDogRegistration();
+    const userId = useUserStore().user?.id;
 
     const {
         register,
@@ -85,7 +88,7 @@ export default function Register() {
             neuterYn: transformneuterYn(data.neuterYn as boolean),
         };
 
-        const response = await registerDog(transformedData);
+        const response = await registerDog(transformedData, img, userId!);
         if (response) {
             setTimeout(() => {
                 setStep(5); // 성공 시 1초 후 완료 단계로 이동
@@ -160,6 +163,7 @@ export default function Register() {
                                 setValue={setValue}
                                 imgName={imgName}
                                 setImgName={setImgName}
+                                setImg={setImg}
                             />
                         </motion.div>
                     )}

--- a/src/types/register.d.ts
+++ b/src/types/register.d.ts
@@ -59,6 +59,7 @@ export interface RegisterStep2Props {
     setValue: UseFormSetValue<RegisterFormData>;
     imgName: string;
     setImgName: React.Dispatch<React.SetStateAction<string>>;
+    setImg: React.Dispatch<React.SetStateAction<File | null>>;
 }
 
 export interface RegisterStep3Props {
@@ -90,11 +91,12 @@ export interface DogRegistrationRequest {
 
 // 반려견 등록 응답 타입
 export interface DogRegistrationResponse extends BaseApiResponse {
-    result?: {
-        path?: string;
-        responseCode?: string;
-        message?: string;
-        timeStamp?: string;
+    data: {
+        responsecode: string;
+        result: {
+            UUID: number;
+            resultImgURL: string;
+        };
     };
 }
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

동물등록시 s3 이미지 업로드 로직 적용

## 📌 이슈 넘버

- #145 

## 📝 작업 내용

메인 변경사항
- 동물 등록시 동물의 프로필 이미지에 s3 업로드 로직 첨가
- 동물 등록 시 presigned s3 url 이용한 방식으로 변경
- api test 완료

부가 변경사항
- 동물 등록 완료 시 조사 처리 살짝 수정
- 동물 이름의 마지막 글자의 종성 유무에 따라, 자연스럽게 '~이는' 또는 '~는'으로 보이도록 설정
   - 변경 전   
   
   ![image](https://github.com/user-attachments/assets/f253c86d-c7a6-44c5-af1a-c8f1a03f2cc7)
   - 변경 후
   
   ![image](https://github.com/user-attachments/assets/88482dcb-3512-4021-b914-3d05ed32b00f)



## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

끝나고 브랜치 삭제해주시면 감사합니다! 
동물 정보 수정 페이지는, 제가 부탁 쪽을 작업해야해서 혹시 다른분께서 해주실 수 있으시다면 해주시면 감사합니다~~!!
