### PR TITLE
[Feat] 인트로 페이지 슬라이더 skip 지정 및 카카로 회원가입 초기값 지정

### DIFF
--- a/src/components/kakao/KakaoThirdStep.tsx
+++ b/src/components/kakao/KakaoThirdStep.tsx
@@ -1,19 +1,28 @@
+import { useEffect } from 'react';
+import { useUserStore } from '@/stores'; // Zustand store import
 import {
     introduceValidationType,
     nicknameValidationType,
     KakaoSignUpInputs,
 } from '@/hooks/useKakaoForm';
 import { CustomInput, ImageSelectBox } from '../common';
-import { FieldErrors, UseFormRegister, UseFormWatch } from 'react-hook-form';
+import {
+    FieldErrors,
+    UseFormRegister,
+    UseFormWatch,
+    UseFormSetValue,
+} from 'react-hook-form';
 import { useCallback } from 'react';
 
 interface ThirdStepPropsType {
     pageNumber: number;
     register: UseFormRegister<KakaoSignUpInputs>;
     watch: UseFormWatch<KakaoSignUpInputs>;
+    setValue: UseFormSetValue<KakaoSignUpInputs>; // 추가
     nicknameValidation: nicknameValidationType;
     introduceValidation: introduceValidationType;
     errors: FieldErrors<KakaoSignUpInputs>;
+
     setPageNumber: React.Dispatch<React.SetStateAction<number>>;
     imgName: string;
     setImgName: React.Dispatch<React.SetStateAction<string>>;
@@ -24,6 +33,7 @@ export default function ThirdStep({
     pageNumber,
     register,
     watch,
+    setValue, // 추가
     nicknameValidation,
     introduceValidation,
     errors,
@@ -32,12 +42,21 @@ export default function ThirdStep({
     setImgName,
     setImg,
 }: ThirdStepPropsType) {
+    const { user } = useUserStore(); // Zustand에서 닉네임 가져오기
+
+    // 닉네임 초기값 설정
+    useEffect(() => {
+        if (user?.nickname) {
+            setValue('nickname', user.nickname); // React Hook Form에 초기값 설정
+        }
+    }, [user?.nickname, setValue]);
+
     const nickname = watch('nickname');
     const introduce = watch('introduce');
 
     const handleNextBtn = useCallback(() => {
         setPageNumber((prev) => prev + 1);
-    }, []);
+    }, [setPageNumber]);
 
     return (
         <>

--- a/src/components/kakao/Success.tsx
+++ b/src/components/kakao/Success.tsx
@@ -2,44 +2,10 @@ import Logo from '@/assets/images/header/logo.svg?react';
 import SmallDog from '@/assets/images/login/smallDog.svg?react';
 import { DotLottieReact } from '@lottiefiles/dotlottie-react';
 import { useUserStore } from '@/stores';
-import { useEffect, useState } from 'react';
-import { getMyProfileInfo } from '@/hooks/api/user';
-import { Loading } from '../common';
 
 // 카카오 회원가입 성공시 화면
 export default function Success() {
     const { user } = useUserStore();
-    const { setUser } = useUserStore();
-    const [loading, setLoading] = useState(false);
-    useEffect(() => {
-        const fetchProfile = async () => {
-            const response = await getMyProfileInfo();
-            if (response.ok) {
-                const { id, accountId, nickname, isRegistered, region } =
-                    response.data;
-                setUser({
-                    id,
-                    accountId,
-                    nickname,
-                    isRegistered,
-                    region,
-                });
-                setLoading(true);
-            } else {
-                console.log('Failed to retrieve profile', response.error);
-            }
-        };
-
-        fetchProfile();
-    }, []);
-    if (!loading) {
-        return (
-            <div className="bg-white h-full flex justify-center items-center">
-                <Loading />
-            </div>
-        );
-    }
-
     return (
         <div className="h-screen bg-white flex flex-col justify-between overflow-hidden">
             <header className="h-14 w-full flex items-center justify-center">

--- a/src/hooks/useKakaoForm.ts
+++ b/src/hooks/useKakaoForm.ts
@@ -4,7 +4,7 @@ import useFadeNavigate from './useFadeNavigate';
 import { useCustomToast } from '@/components/common';
 import { postkakaoSignup } from './api/user';
 import { putImageToS3 } from './api/auth';
-
+import { useUserStore } from '@/stores';
 /**
  * Kakao Signup form types
  */
@@ -70,15 +70,25 @@ const getLocation = () => {
  * @returns {Object} Form methods and handlers
  */
 export default function useKakaoSignupForm() {
+    const { user } = useUserStore();
     const {
         register,
         handleSubmit,
         watch,
+        setValue,
         formState: { errors, isValid },
         control,
     } = useForm<KakaoSignUpInputs>({
         shouldFocusError: false,
         mode: 'onChange',
+        defaultValues: {
+            nickname: user?.nickname || '', // Zustand에서 닉네임 가져오기
+            introduce: '', // introduce 초기화
+            genderBool: true,
+            possible: false,
+            dogSizes: [],
+            mbti: '',
+        },
     });
 
     const [pageNumber, setPageNumber] = useState(3);
@@ -202,6 +212,7 @@ export default function useKakaoSignupForm() {
         onSubmit,
         isValid,
         control,
+        setValue,
         success,
         imgName,
         setImgName,

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Logo from '@/assets/images/header/logo.svg?react';
 import KakaoLogo from '@/assets/images/intro/kakaoLogo.svg?react';
 import AtSign from '@/assets/images/intro/atSign.svg?react';
@@ -10,10 +10,27 @@ export default function Intro() {
     const [currentSlide, setCurrentSlide] = useState(0);
     const totalSlides = 3;
     const navigate = useFadeNavigate();
+
+    // 로컬 스토리지에서 슬라이더 상태를 불러오기
+    useEffect(() => {
+        const savedSlide = localStorage.getItem('lastSlide');
+        if (savedSlide) {
+            setCurrentSlide(Number(savedSlide));
+        }
+    }, []);
+
+    // 사용자가 3번째 슬라이더에 도달했을 때 로컬 스토리지에 저장
+    useEffect(() => {
+        if (currentSlide === totalSlides - 1) {
+            localStorage.setItem('lastSlide', String(totalSlides - 1));
+        }
+    }, [currentSlide]);
+
     const handleKakaoLogin = () => {
         // 백엔드 카카오 로그인 링크로 리다이렉트
         window.location.href = '/oauth2/authorization/kakao';
     };
+
     return (
         <div className="min-h-screen bg-white flex flex-col items-center justify-between overflow-hidden">
             <header className="h-14 w-full flex items-center justify-center">

--- a/src/pages/KakaoSignup.tsx
+++ b/src/pages/KakaoSignup.tsx
@@ -1,13 +1,41 @@
+import { useState, useCallback, useEffect } from 'react';
 import Back from '@/assets/images/header/back.svg?react';
 import { Loading } from '@/components/common';
-import { KakaoFourthStep, KakaoThirdStep } from '@/components/kakao';
-import Success from '@/components/kakao/Success';
+import { KakaoFourthStep, KakaoThirdStep, Success } from '@/components/kakao';
 import { useFadeNavigate } from '@/hooks';
+import { getMyProfileInfo } from '@/hooks/api/user';
 import useKakaoSignupForm from '@/hooks/useKakaoForm';
-import { useCallback } from 'react';
+import { useUserStore } from '@/stores';
 
 export default function KakaoSignup() {
     const navigate = useFadeNavigate();
+    const { setUser } = useUserStore();
+    const [loading, setLoading] = useState(true); // 추가: 프로필 데이터 로딩 상태 관리
+
+    // Zustand에서 유저 정보를 가져오거나 초기화
+    useEffect(() => {
+        const fetchProfile = async () => {
+            const response = await getMyProfileInfo();
+            if (response.ok) {
+                const { id, accountId, nickname, isRegistered, region } =
+                    response.data;
+                setUser({
+                    id,
+                    accountId,
+                    nickname,
+                    isRegistered,
+                    region,
+                });
+            } else {
+                console.error('Failed to retrieve profile:', response.error);
+            }
+            setLoading(false); // 로딩 완료
+        };
+
+        fetchProfile();
+    }, [setUser]);
+
+    // useKakaoSignupForm 훅
     const {
         pageNumber,
         setPageNumber,
@@ -18,76 +46,80 @@ export default function KakaoSignup() {
         watch,
         errors,
         onSubmit,
+        setValue,
         isValid,
         control,
         success,
         imgName,
         setImgName,
-        loading,
+        setImg,
         showModal,
         setShowModal,
-        setImg,
     } = useKakaoSignupForm();
 
+    // 뒤로가기 버튼 핸들러
     const handleBackBtn = useCallback(() => {
         if (pageNumber === 1) {
             navigate(-1);
         } else {
             setPageNumber((prev) => prev - 1);
         }
-    }, [pageNumber]);
+    }, [pageNumber, navigate, setPageNumber]);
 
+    // 로딩 상태 처리
+    if (loading) {
+        return (
+            <div className="bg-white h-full flex justify-center items-center">
+                <Loading />
+            </div>
+        );
+    }
+
+    // 성공 화면
     if (success) return <Success />;
 
+    // 회원가입 폼 화면
     return (
-        <>
-            {loading && (
-                <div className="bg-white h-full flex justify-center items-center">
-                    <Loading />
-                </div>
-            )}
-            <div
-                className={`${loading && 'hidden'} h-screen bg-gray-100 flex flex-col overflow-hidden`}
+        <div className="h-screen bg-gray-100 flex flex-col overflow-hidden">
+            <header className="bg-white h-14 w-full flex items-center justify-center">
+                <Back
+                    onClick={handleBackBtn}
+                    className="absolute left-[26px] cursor-pointer"
+                />
+                <h1 className="text-point-900 text-body-l font-extrabold">
+                    회원가입
+                </h1>
+            </header>
+            <form
+                id="signup-form"
+                onSubmit={handleSubmit(onSubmit)}
+                className="h-full flex-1 flex flex-col justify-between"
             >
-                <header className="bg-white h-14 w-full flex items-center justify-center">
-                    <Back
-                        onClick={handleBackBtn}
-                        className="absolute left-[26px] cursor-pointer"
-                    />
-                    <h1 className="text-point-900 text-body-l font-extrabold">
-                        회원가입
-                    </h1>
-                </header>
-                <form
-                    id="signup-form"
-                    onSubmit={handleSubmit(onSubmit)}
-                    className="h-full flex-1 flex flex-col justify-between"
-                >
-                    <KakaoThirdStep
-                        pageNumber={pageNumber}
-                        register={register}
-                        watch={watch}
-                        nicknameValidation={nicknameValidation}
-                        introduceValidation={introduceValidation}
-                        errors={errors}
-                        setPageNumber={setPageNumber}
-                        imgName={imgName}
-                        setImgName={setImgName}
-                        setImg={setImg}
-                    />
-                    <KakaoFourthStep
-                        pageNumber={pageNumber}
-                        register={register}
-                        watch={watch}
-                        errors={errors}
-                        control={control}
-                        isValid={isValid}
-                        loading={loading}
-                        showModal={showModal}
-                        setShowModal={setShowModal}
-                    />
-                </form>
-            </div>
-        </>
+                <KakaoThirdStep
+                    pageNumber={pageNumber}
+                    register={register}
+                    watch={watch}
+                    setValue={setValue}
+                    nicknameValidation={nicknameValidation}
+                    introduceValidation={introduceValidation}
+                    errors={errors}
+                    setPageNumber={setPageNumber}
+                    imgName={imgName}
+                    setImgName={setImgName}
+                    setImg={setImg}
+                />
+                <KakaoFourthStep
+                    pageNumber={pageNumber}
+                    register={register}
+                    watch={watch}
+                    errors={errors}
+                    control={control}
+                    isValid={isValid}
+                    loading={loading}
+                    showModal={showModal}
+                    setShowModal={setShowModal}
+                />
+            </form>
+        </div>
     );
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

>인트로 페이지 슬라이더 skip 지정 및 카카로 회원가입 초기값 지정

## 📌 이슈 넘버

> ex) #159 

## 📝 작업 내용
- 기존 :  인트로 페이지 슬라이더 마지막 페이지에서 로그인 간능
- 변경 후 : 재사용자는 첫 슬라이더에서 로그인으로 이동가능
- 카카오 회원가입시 기본정보 초기값 지정 
## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/639fdba7-ebf1-43f3-b968-048a14113fa4)
![image](https://github.com/user-attachments/assets/822594f9-8d40-4563-89cc-d4935d2dde27)

## 💬추후 수정 내용

> 이미지 업로드 코드 수정
