### PR TITLE
[Feat] 돌봄 상태에 따른 렌더링 활성화/비활성화

### DIFF
--- a/src/components/please/DogInformation.tsx
+++ b/src/components/please/DogInformation.tsx
@@ -7,9 +7,10 @@ import { formatDate, formatTime } from '@/utils';
 import { MissionInfo } from '@/types/please';
 interface DogInfoProps {
     missionInfo: MissionInfo;
+    status: string;
 }
 
-export default function DogInformation({ missionInfo }: DogInfoProps) {
+export default function DogInformation({ missionInfo, status }: DogInfoProps) {
     const settings = {
         dots: true,
         infinite: false,
@@ -33,6 +34,10 @@ export default function DogInformation({ missionInfo }: DogInfoProps) {
         temperament: pet.temperament,
         size: pet.size,
     }));
+
+    const getInputClassName = () => {
+        return `input-outline ${status === 'INP' ? 'border-point-300' : ''} flex-1 mr-2 sm:!px-4 px-3`;
+    };
 
     return (
         <main className="p-4 overflow-y-auto h-full scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent">
@@ -73,6 +78,14 @@ export default function DogInformation({ missionInfo }: DogInfoProps) {
                     </div>
                 </div>
 
+                {status === 'INP' && (
+                    <div className="bg-point-50 rounded-lg p-4 mt-6">
+                        <p className="text-point-500 text-body-s font-semibold">
+                            현재 돌봄이 진행중입니다
+                        </p>
+                    </div>
+                )}
+
                 <div className="space-y-2 mt-6">
                     <div>
                         <p className="text-label-m text-gray-500 mb-2">
@@ -81,13 +94,13 @@ export default function DogInformation({ missionInfo }: DogInfoProps) {
                         <div className="flex items-center">
                             <input
                                 id="startDate"
-                                className="input-outline flex-1 mr-2 sm:!px-4 px-3"
+                                className={getInputClassName()}
                                 value={formatDate(missionInfo.receiverStart)}
                                 readOnly
                             />
                             <input
                                 id="startTime"
-                                className="input-outline text-gray-400 md:!w-[135px] w-[105px] sm:!px-4 px-3"
+                                className={`input-outline ${status === 'INP' ? 'border-point-300' : ''} text-gray-400 md:!w-[135px] w-[105px] sm:!px-4 px-3`}
                                 value={formatTime(missionInfo.receiverStart)}
                                 readOnly
                             />
@@ -100,24 +113,26 @@ export default function DogInformation({ missionInfo }: DogInfoProps) {
                         <div className="flex items-center">
                             <input
                                 id="startDate"
-                                className="input-outline flex-1 mr-2 sm:!px-4 px-3"
+                                className={getInputClassName()}
                                 value={formatDate(missionInfo.receiverEnd)}
                                 readOnly
                             />
                             <input
                                 id="startTime"
-                                className="input-outline text-gray-400 md:!w-[135px] w-[105px] sm:!px-4 px-3"
+                                className={`input-outline ${status === 'INP' ? 'border-point-300' : ''} text-gray-400 md:!w-[135px] w-[105px] sm:!px-4 px-3`}
                                 value={formatTime(missionInfo.receiverEnd)}
                                 readOnly
                             />
                         </div>
                     </div>
                 </div>
-                <div className="flex justify-center">
-                    <button className="text-label-m text-gray-600 border-b border-b-gray-600 w-fit my-4">
-                        멍멍이의 부탁 삭제
-                    </button>
-                </div>
+                {status === 'BEF' && (
+                    <div className="flex justify-center">
+                        <button className="text-label-m text-gray-600 border-b border-b-gray-600 w-fit my-4">
+                            멍멍이의 부탁 삭제
+                        </button>
+                    </div>
+                )}
             </div>
         </main>
     );

--- a/src/components/please/RequestList.tsx
+++ b/src/components/please/RequestList.tsx
@@ -8,9 +8,15 @@ import { MissionInfo } from '@/types/please';
 
 interface RequestListProps {
     missionInfo: MissionInfo;
+    status: string;
+    userId?: number;
 }
 
-export default function RequestList({ missionInfo }: RequestListProps) {
+export default function RequestList({
+    missionInfo,
+    status,
+    userId,
+}: RequestListProps) {
     const settings = {
         dots: true,
         infinite: false,
@@ -37,13 +43,13 @@ export default function RequestList({ missionInfo }: RequestListProps) {
     }));
 
     return (
-        <main className="flex flex-col flex-1 overflow-hidden">
+        <main className="p-4 flex flex-col flex-1 overflow-hidden">
             <div className="flex flex-col flex-1">
-                <h1 className="sm:text-title-s text-body-l font-extrabold text-gray-800 sm:pt-8 pt-5 pb-4 px-6">
+                <h1 className="sm:text-title-s text-body-l font-extrabold text-gray-800 sm:pt-8 pt-1 pb-5">
                     <p>멍멍이와 함께</p>
                     <p>미션을 시작해볼까요?</p>
                 </h1>
-                <div className="flex flex-col px-6">
+                <div className="flex flex-col">
                     <div className="slider-container">
                         {dogs.length === 1 ? (
                             // 한 마리일 때는 일반 div로 표시
@@ -63,6 +69,9 @@ export default function RequestList({ missionInfo }: RequestListProps) {
                     </div>
                     <RequestListAccordion
                         petMissionAskInfos={missionInfo.petMissionAskInfos}
+                        status={status}
+                        userId={userId}
+                        receiverId={missionInfo.receiverId}
                     />
                 </div>
             </div>

--- a/src/components/please/RequestListAccordion.tsx
+++ b/src/components/please/RequestListAccordion.tsx
@@ -5,8 +5,13 @@ import { Request, RequestListAccordionProps } from '@/types/please';
 
 export default function RequestListAccordion({
     petMissionAskInfos,
+    status,
+    userId,
+    receiverId,
 }: RequestListAccordionProps) {
     const [showMenu, setShowMenu] = useState(false);
+
+    const canRegister = status === 'INP' && userId === receiverId;
 
     const requests: Request[] = petMissionAskInfos.map((ask, index) => ({
         id: ask.id || index,
@@ -104,12 +109,16 @@ export default function RequestListAccordion({
                                             <p className="flex-1 text-body-s font-semibold text-gray-900">
                                                 <strong>{request.ask}</strong>{' '}
                                             </p>
-                                            <button
-                                                onClick={handleRegisterRequest}
-                                                className="text-label-m w-fit p-2 text-point-500 hover:bg-gray-200 rounded-lg transition-colors"
-                                            >
-                                                기록하기
-                                            </button>
+                                            {canRegister && (
+                                                <button
+                                                    onClick={
+                                                        handleRegisterRequest
+                                                    }
+                                                    className="text-label-m w-fit p-2 text-point-500 hover:bg-gray-200 rounded-lg transition-colors"
+                                                >
+                                                    기록하기
+                                                </button>
+                                            )}
                                         </div>
                                     </motion.div>
                                 ))}

--- a/src/pages/PleaseDetail.tsx
+++ b/src/pages/PleaseDetail.tsx
@@ -11,60 +11,60 @@ import { useUserStore } from '@/stores';
 export default function PleaseDetail() {
     const { id } = useParams(); // 부탁에 대한 id
     const userId = useUserStore().user?.id; // userId
-    // const { data: missionInfo, isLoading, error } = usePetMissionInfo(id!);
+    const { data: missionInfo, isLoading, error } = usePetMissionInfo(id!);
     const navigate = useFadeNavigate();
     const [isInfoTab, setIsInfoTab] = useState(true);
     // console.log(missionInfo?.result);
-    const missionInfo = {
-        result: {
-            id: 1,
-            careName: '파워', // 맡김이
-            careId: 2,
-            receiverName: 'gunwoo121112', // 돌봄이
-            receiverId: 1,
-            receiverStart: '2024-12-01T10:00:00',
-            receiverEnd: '2024-12-01T12:00:00',
-            petMissionPetInfos: [
-                {
-                    petName: '야호22',
-                    breed: '페키니2즈',
-                    age: 17,
-                    gender: 'FEMALE' as 'FEMALE' | 'MALE',
-                    neuterYn: '중성',
-                    temperament: 'ENFP',
-                    size: 'SMALL',
-                    profileImg: 'https://cdn.pixabay.com/photo',
-                },
-            ],
-            petMissionAskInfos: [
-                {
-                    id: null,
-                    comment: null,
-                    ask: 'Feed the dog',
-                    imgURL: null,
-                },
-                {
-                    id: null,
-                    comment: null,
-                    ask: 'Walk the dog',
-                    imgURL: null,
-                },
-                {
-                    id: null,
-                    comment: null,
-                    ask: 'Walk the dog',
-                    imgURL: null,
-                },
-                {
-                    id: null,
-                    comment: null,
-                    ask: 'Walk the dog',
-                    imgURL: null,
-                },
-            ],
-            status: 'INP' as 'BEF' | 'AFT' | 'INP',
-        },
-    };
+    // const missionInfo = {
+    //     result: {
+    //         id: 1,
+    //         careName: '파워', // 맡김이
+    //         careId: 2,
+    //         receiverName: 'gunwoo121112', // 돌봄이
+    //         receiverId: 1,
+    //         receiverStart: '2024-12-01T10:00:00',
+    //         receiverEnd: '2024-12-01T12:00:00',
+    //         petMissionPetInfos: [
+    //             {
+    //                 petName: '야호22',
+    //                 breed: '페키니2즈',
+    //                 age: 17,
+    //                 gender: 'FEMALE' as 'FEMALE' | 'MALE',
+    //                 neuterYn: '중성',
+    //                 temperament: 'ENFP',
+    //                 size: 'SMALL',
+    //                 profileImg: 'https://cdn.pixabay.com/photo',
+    //             },
+    //         ],
+    //         petMissionAskInfos: [
+    //             {
+    //                 id: null,
+    //                 comment: null,
+    //                 ask: 'Feed the dog',
+    //                 imgURL: null,
+    //             },
+    //             {
+    //                 id: null,
+    //                 comment: null,
+    //                 ask: 'Walk the dog',
+    //                 imgURL: null,
+    //             },
+    //             {
+    //                 id: null,
+    //                 comment: null,
+    //                 ask: 'Walk the dog',
+    //                 imgURL: null,
+    //             },
+    //             {
+    //                 id: null,
+    //                 comment: null,
+    //                 ask: 'Walk the dog',
+    //                 imgURL: null,
+    //             },
+    //         ],
+    //         status: 'INP' as 'BEF' | 'AFT' | 'INP',
+    //     },
+    // };
 
     const handleBackBtn = useCallback(() => {
         navigate(-1);
@@ -89,8 +89,8 @@ export default function PleaseDetail() {
 
     const isButtonDisabled = missionInfo?.result.status === 'AFT';
 
-    // if (isLoading) return <Loading />;
-    // if (error) return <div>에러가 발생했습니다.</div>;
+    if (isLoading) return <Loading />;
+    if (error) return <div>에러가 발생했습니다.</div>;
 
     const pageVariants = {
         initial: {

--- a/src/pages/PleaseDetail.tsx
+++ b/src/pages/PleaseDetail.tsx
@@ -6,13 +6,65 @@ import Back from '@/assets/images/header/back.svg?react';
 import { CustomToggle, Loading, ToastAnchor } from '@/components/common';
 import DogInfoComponent from '@/components/please/DogInformation';
 import RequestListComponent from '@/components/please/RequestList';
+import { useUserStore } from '@/stores';
 
 export default function PleaseDetail() {
-    const { id } = useParams();
-    const { data: missionInfo, isLoading, error } = usePetMissionInfo(id!);
+    const { id } = useParams(); // 부탁에 대한 id
+    const userId = useUserStore().user?.id; // userId
+    // const { data: missionInfo, isLoading, error } = usePetMissionInfo(id!);
     const navigate = useFadeNavigate();
     const [isInfoTab, setIsInfoTab] = useState(true);
-    console.log(missionInfo?.result);
+    // console.log(missionInfo?.result);
+    const missionInfo = {
+        result: {
+            id: 1,
+            careName: '파워', // 맡김이
+            careId: 2,
+            receiverName: 'gunwoo121112', // 돌봄이
+            receiverId: 1,
+            receiverStart: '2024-12-01T10:00:00',
+            receiverEnd: '2024-12-01T12:00:00',
+            petMissionPetInfos: [
+                {
+                    petName: '야호22',
+                    breed: '페키니2즈',
+                    age: 17,
+                    gender: 'FEMALE' as 'FEMALE' | 'MALE',
+                    neuterYn: '중성',
+                    temperament: 'ENFP',
+                    size: 'SMALL',
+                    profileImg: 'https://cdn.pixabay.com/photo',
+                },
+            ],
+            petMissionAskInfos: [
+                {
+                    id: null,
+                    comment: null,
+                    ask: 'Feed the dog',
+                    imgURL: null,
+                },
+                {
+                    id: null,
+                    comment: null,
+                    ask: 'Walk the dog',
+                    imgURL: null,
+                },
+                {
+                    id: null,
+                    comment: null,
+                    ask: 'Walk the dog',
+                    imgURL: null,
+                },
+                {
+                    id: null,
+                    comment: null,
+                    ask: 'Walk the dog',
+                    imgURL: null,
+                },
+            ],
+            status: 'INP' as 'BEF' | 'AFT' | 'INP',
+        },
+    };
 
     const handleBackBtn = useCallback(() => {
         navigate(-1);
@@ -22,8 +74,23 @@ export default function PleaseDetail() {
         setIsInfoTab(checked);
     };
 
-    if (isLoading) return <Loading />;
-    if (error) return <div>에러가 발생했습니다.</div>;
+    const getButtonText = () => {
+        switch (missionInfo?.result.status) {
+            case 'BEF':
+                return '멍멍이 돌봄 시작하기';
+            case 'INP':
+                return '돌봄 완료하기';
+            case 'AFT':
+                return '돌봄 완료';
+            default:
+                return '멍멍이 돌봄 시작하기';
+        }
+    };
+
+    const isButtonDisabled = missionInfo?.result.status === 'AFT';
+
+    // if (isLoading) return <Loading />;
+    // if (error) return <div>에러가 발생했습니다.</div>;
 
     const pageVariants = {
         initial: {
@@ -82,6 +149,7 @@ export default function PleaseDetail() {
                                     {missionInfo && (
                                         <DogInfoComponent
                                             missionInfo={missionInfo.result}
+                                            status={missionInfo.result.status}
                                         />
                                     )}
                                 </motion.div>
@@ -98,6 +166,8 @@ export default function PleaseDetail() {
                                     {missionInfo && (
                                         <RequestListComponent
                                             missionInfo={missionInfo.result}
+                                            status={missionInfo.result.status}
+                                            userId={userId}
                                         />
                                     )}
                                 </motion.div>
@@ -110,8 +180,12 @@ export default function PleaseDetail() {
             {/* Footer - Fixed */}
             <footer className="w-full max-w-[600px] px-6 py-2.5 mx-auto shrink-0">
                 <ToastAnchor>
-                    <button type="submit" className="btn-solid">
-                        멍멍이 돌봄 시작하기
+                    <button
+                        type="submit"
+                        className={`btn-solid ${isButtonDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                        disabled={isButtonDisabled}
+                    >
+                        {getButtonText()}
                     </button>
                 </ToastAnchor>
             </footer>

--- a/src/types/please.d.ts
+++ b/src/types/please.d.ts
@@ -52,7 +52,9 @@ interface PetMissionInfoResponse extends BaseApiResponse {
         result: {
             id: number;
             careName: string;
+            careId: number;
             receiverName: string;
+            receiverId: number;
             receiverStart: string;
             receiverEnd: string;
             petMissionPetInfos: PetInfo[];

--- a/src/types/please.d.ts
+++ b/src/types/please.d.ts
@@ -65,7 +65,9 @@ interface PetMissionInfoResponse extends BaseApiResponse {
 interface MissionInfo {
     id: number;
     careName: string;
+    careId: number;
     receiverName: string;
+    receiverId: number;
     receiverStart: string;
     receiverEnd: string;
     petMissionPetInfos: PetInfo[];
@@ -82,6 +84,9 @@ interface Request {
 
 interface RequestListAccordionProps {
     petMissionAskInfos: Request[];
+    status: string;
+    userId?: number;
+    receiverId?: number;
 }
 
 export type {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

돌봄 상태에 따른 렌더링 활성화/비활성화

## 📌 이슈 넘버

- #154

## 📝 작업 내용

현재 부탁 상세조회 api 연동 및 test는 완료되었습니다.
백엔드의 response body에서 추가 필드를 작업중인 관계로 , 테스트용 dummydata를 쓰고 일단 주석처리 해두었습니다.

status가 'BEF'(돌봄 시작 전)일때
-  [x] 삭제 버튼 활성화
-  [x] 미션 아코디언 '등록하기'버튼 비활성화

status가 'INP'(진행중)일때
- [x] 삭제 버튼 비활성화
- [x] 하단 버튼 '돌봄 완료하기'로 변경
- [x] 미션 아코디언 '등록하기' 버튼 활성화 -> 돌봄이만
- [x] '돌봄이 진행중입니다' 안내문구 추가 -> 원래 피그마 디자인에 없던건데, 직관적으로 보이도록 추가하였습니다.

status가 'AFT'(돌봄 완료 후) 일때
- [x] 하단 버튼 '돌봄 완료' 및 비활성화 시키기
- [x] 미션 아코디언 '등록하기' 버튼 비활성화

## 📸 스크린샷(선택)
1. status가 'BEF'(돌봄 시작 전)일때
![chrome-capture-2024-12-7](https://github.com/user-attachments/assets/a8c68036-c8f1-47ed-bc07-c53b7d6d18c2)


2. status가 'INP'(진행중)일때
![chrome-capture-2024-12-7 (1)](https://github.com/user-attachments/assets/b07c0423-7385-4157-b1fd-9cc8f913a255)


3, status가 'AFT'(돌봄 완료 후) 일때
![chrome-capture-2024-12-7 (2)](https://github.com/user-attachments/assets/2c6b73b4-7f9b-4138-96b4-1f40545853cd)


## 💬리뷰 요구사항(선택)

 **브랜치 삭제하지 말아주세용~~**

남은 추가작업은 아래와 같습니다.

추가 작업

- [x] 미션 아코디언에 '등록하기' 퍼블리싱 추가  
- [x] 각 미션의 '등록하기' 누르면, 모달창에서(아마도?) 미션에 대한 사진 및 간단한 콘텐츠 작성할 수 있도록 하기  
- [ ] 미션 등록 API 타입 생성  
- [ ] 미션 등록 API 테스트  
