### PR TITLE
[Bug] 돌봄 상세페이지 강아지 프로필사진 안보임 해결

### DIFF
--- a/src/components/please/DogInformation.tsx
+++ b/src/components/please/DogInformation.tsx
@@ -39,7 +39,7 @@ export default function DogInformation({
         sexNm: pet.gender === 'FEMALE' ? '암컷' : '수컷',
         kindNm: pet.breed,
         neuterYn: pet.neuterYn,
-        profileImg: pet.profileImg, // 기본 이미지
+        profileImg: pet.imgURL, // 기본 이미지
         age: pet.age,
         temperament: pet.temperament,
         size: pet.size,

--- a/src/components/please/RequestList.tsx
+++ b/src/components/please/RequestList.tsx
@@ -36,7 +36,7 @@ export default function RequestList({
         sexNm: pet.gender === 'FEMALE' ? '암컷' : '수컷',
         kindNm: pet.breed,
         neuterYn: pet.neuterYn,
-        profileImg: pet.profileImg, // 기본 이미지
+        profileImg: pet.imgURL, // 기본 이미지
         age: pet.age,
         temperament: pet.temperament,
         size: pet.size,

--- a/src/types/please.d.ts
+++ b/src/types/please.d.ts
@@ -61,7 +61,7 @@ interface PetInfo {
     neuterYn: string; // '중성' | '미중성',
     temperament: string;
     size: string;
-    profileImg: string;
+    imgURL: string;
 }
 
 // 미션 요청 정보 타입


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

돌봄 상세페이지 강아지 프로필사진 안보임 해결

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/9e809cf7-99cf-488d-ad14-29257105b08d)
![image](https://github.com/user-attachments/assets/23ce545d-0f5c-421d-aecf-e44b721628ef)

