### PR TITLE
[Feat] 프로필 수정 페이지 비밀번호 변경 페이지 버튼 추가

### DIFF
--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -69,6 +69,10 @@ export default function ProfileEdit() {
         navigate('/delete-account');
     }, [navigate]);
 
+    const handleChangePasswordBtn = useCallback(() => {
+        navigate('/change-password');
+    }, [navigate]);
+
     const updateProfile = useCallback(async () => {
         const response = await editMyProfileInfo({
             nickname,
@@ -281,6 +285,14 @@ export default function ProfileEdit() {
                         수정 완료
                     </button>
                 </ToastAnchor>
+                <div className="flex items-center justify-center mt-8">
+                    <button
+                        onClick={handleChangePasswordBtn}
+                        className="text-label-l  underline text-gray-400 p-1"
+                    >
+                        비밀번호 변경
+                    </button>
+                </div>
                 <div className="flex items-center justify-center mt-8">
                     <button
                         onClick={handleDeleteAccountBtn}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

프로필 수정 페이지에 사용자의 비밀번호를 변경할 수 있는 페이지로 이동하는 버튼을 추가합니다.

## 📌 이슈 넘버

- #98 

## 📝 작업 내용

- 프로필 수정 페이지에 비밀번호 변경 페이지로 navigate하는 버튼 추가

## 📸 스크린샷(선택)

![프로필](https://github.com/user-attachments/assets/e5cce9dd-3c2b-4439-a257-1001f80cf955)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
